### PR TITLE
Implement peek() as it should be implemented

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -248,7 +248,10 @@ int WiFiClient::read(uint8_t* buf, size_t size)
 
 int WiFiClient::peek()
 {
-	return read();
+	if (!available())
+		return -1;
+
+	return _buffer[_tail];
 }
 
 void WiFiClient::flush()


### PR DESCRIPTION
Solves a nasty bug with Temboo library, which uses `parseInt`, which uses `peek`