### PR TITLE
Change read to return up to available bytes

### DIFF
--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -95,7 +95,9 @@ uint8_t WiFiUDP::begin(uint16_t port)
 /* return number of bytes available in the current packet,
    will return zero if parsePacket hasn't been called yet */
 int WiFiUDP::available()
-{	
+{
+	m2m_wifi_handle_events(NULL);
+	
 	if (_socket != -1) {
 		return _rcvSize;
 	}

--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -95,9 +95,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
 /* return number of bytes available in the current packet,
    will return zero if parsePacket hasn't been called yet */
 int WiFiUDP::available()
-{
-	m2m_wifi_handle_events(NULL);
-	
+{	
 	if (_socket != -1) {
 		return _rcvSize;
 	}

--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -99,14 +99,7 @@ int WiFiUDP::available()
 	m2m_wifi_handle_events(NULL);
 	
 	if (_socket != -1) {
-		if (_rcvSize != 0) {
-			if (_head - _tail > _rcvSize) {
-				return _rcvSize;
-			}
-			else {
-				return _head - _tail;
-			}
-		}
+		return _rcvSize;
 	}
 	return 0;
  }

--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -190,22 +190,10 @@ int WiFiUDP::read()
 {
 	uint8_t b;
 
-	if (!available())
+	if (read(&b, sizeof(b)) == -1) {
 		return -1;
-
-	b = _buffer[_tail++];
-	_rcvSize -= 1;
-	if (_tail == _head) {
-		_tail = _head = 0;
-		_flag &= ~SOCKET_BUFFER_FLAG_FULL;
-		if (hif_small_xfer) {
-			recvfrom(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
-		}
-		else {
-			recvfrom(_socket, _buffer + SOCKET_BUFFER_UDP_HEADER_SIZE, SOCKET_BUFFER_MTU, 0);			
-		}
-		m2m_wifi_handle_events(NULL);
 	}
+
 	return b;
 }
 
@@ -225,19 +213,17 @@ int WiFiUDP::read(unsigned char* buf, size_t size)
 
 	for (uint32_t i = 0; i < size_tmp; ++i) {
 		buf[i] = _buffer[_tail++];
-	}
-	_rcvSize -= size_tmp;
-	
-	if (_tail == _head) {
-		_tail = _head = 0;
-		_flag &= ~SOCKET_BUFFER_FLAG_FULL;
-		if (hif_small_xfer) {
-			recvfrom(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
+		_rcvSize--;
+
+		if (_tail == _head) {
+			_tail = _head = 0;
+			_flag &= ~SOCKET_BUFFER_FLAG_FULL;
+			if (_rcvSize) {
+				// there are more bytes in the current packet to receive
+				recvfrom(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
+				m2m_wifi_handle_events(NULL);
+			}
 		}
-		else {
-			recvfrom(_socket, _buffer + SOCKET_BUFFER_UDP_HEADER_SIZE, SOCKET_BUFFER_MTU, 0);			
-		}
-		m2m_wifi_handle_events(NULL);
 	}
 
 	return size_tmp;


### PR DESCRIPTION
Resolves #2.

Before read was only returning bytes that were buffered, instead of all the bytes in the parsed packet.

Also, changed available to return the bytes available in the current parsed packet, as per API spec. Previously, it was return bytes available in the buffer, if it was smaller than the packet size.

cc/ @cmaglie @facchinm