### PR TITLE
Always call recvfrom after a packet buffer has been read

### DIFF
--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -220,11 +220,12 @@ int WiFiUDP::read(unsigned char* buf, size_t size)
 		if (_tail == _head) {
 			_tail = _head = 0;
 			_flag &= ~SOCKET_BUFFER_FLAG_FULL;
-			if (_rcvSize) {
-				// there are more bytes in the current packet to receive
+			if (hif_small_xfer) {
 				recvfrom(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
-				m2m_wifi_handle_events(NULL);
+			} else {
+				recvfrom(_socket, _buffer + SOCKET_BUFFER_UDP_HEADER_SIZE, SOCKET_BUFFER_MTU, 0);
 			}
+			m2m_wifi_handle_events(NULL);
 		}
 	}
 

--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -218,8 +218,14 @@ int WiFiUDP::read(unsigned char* buf, size_t size)
 		_rcvSize--;
 
 		if (_tail == _head) {
+			// the full buffered data has been read, reset head and tail for next transfer
 			_tail = _head = 0;
+
+			// clear the buffer full flag
 			_flag &= ~SOCKET_BUFFER_FLAG_FULL;
+
+			// setup buffer and buffer size to transfer the remainder of the current packet
+			// or next received packet
 			if (hif_small_xfer) {
 				recvfrom(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
 			} else {


### PR DESCRIPTION
Always call ``recvfrom`` after received UDP buffer data has been processed, to setup buffer and buffer size for the next transfer. Plus some additional comments in ``WiFiUdp::read```.

As per feedback from @ThibaultRichard. Resolves remainder of the issues with #2.