### PR TITLE
Fix config before begin behaviour

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -44,9 +44,11 @@ static void wifi_cb(uint8_t u8MsgType, void *pvMsg)
 				//SERIAL_PORT_MONITOR.println("wifi_cb: M2M_WIFI_RESP_CON_STATE_CHANGED: DISCONNECTED");
 				if (WiFi._mode == WL_STA_MODE) {
 					WiFi._status = WL_DISCONNECTED;
-					WiFi._localip = 0;
-					WiFi._submask = 0;
-					WiFi._gateway = 0;
+					if (WiFi._dhcp) {
+						WiFi._localip = 0;
+						WiFi._submask = 0;
+						WiFi._gateway = 0;
+					}
 				}
 				// WiFi led OFF.
 				m2m_periph_gpio_set_val(M2M_PERIPH_GPIO15, 1);

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -34,8 +34,7 @@ static void wifi_cb(uint8_t u8MsgType, void *pvMsg)
 			tstrM2mWifiStateChanged *pstrWifiState = (tstrM2mWifiStateChanged *)pvMsg;
 			if (pstrWifiState->u8CurrState == M2M_WIFI_CONNECTED) {
 				//SERIAL_PORT_MONITOR.println("wifi_cb: M2M_WIFI_RESP_CON_STATE_CHANGED: CONNECTED");
-
-				if (!WiFi._dhcp) {
+				if (WiFi._mode == WL_STA_MODE && !WiFi._dhcp) {
 					WiFi._status = WL_CONNECTED;
 
 					// WiFi led ON.

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -386,44 +386,17 @@ uint32_t WiFiClass::provisioned()
 
 void WiFiClass::config(IPAddress local_ip)
 {
-	tstrM2MIPConfig conf;
-
-	conf.u32DNS = 0;
-	conf.u32Gateway = 0;
-	conf.u32StaticIP = (uint32_t)local_ip;
-	conf.u32SubnetMask = 0;
-	m2m_wifi_set_static_ip(&conf);
-	_localip = conf.u32StaticIP;
-	_submask = 0;
-	_gateway = 0;
+	config(local_ip, (uint32_t)0);
 }
 
 void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
 {
-	tstrM2MIPConfig conf;
-
-	conf.u32DNS = (uint32_t)dns_server;
-	conf.u32Gateway = 0;
-	conf.u32StaticIP = (uint32_t)local_ip;
-	conf.u32SubnetMask = 0;
-	m2m_wifi_set_static_ip(&conf);
-	_localip = conf.u32StaticIP;
-	_submask = 0;
-	_gateway = 0;
+	config(local_ip, dns_server, (uint32_t)0);
 }
 
 void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway)
 {
-	tstrM2MIPConfig conf;
-
-	conf.u32DNS = (uint32_t)dns_server;
-	conf.u32Gateway = (uint32_t)gateway;
-	conf.u32StaticIP = (uint32_t)local_ip;
-	conf.u32SubnetMask = 0;
-	m2m_wifi_set_static_ip(&conf);
-	_localip = conf.u32StaticIP;
-	_submask = 0;
-	_gateway = conf.u32Gateway;
+	config(local_ip, dns_server, gateway, (uint32_t)0);
 }
 
 void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet)

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -67,6 +67,7 @@ public:
 	uint32_t _localip;
 	uint32_t _submask;
 	uint32_t _gateway;
+	int _dhcp;
 	uint32_t _resolve;
 	byte *_bssid;
 	wl_mode_t _mode;


### PR DESCRIPTION
Calling ```config``` before ```begin``` would result in DHCP address instead of the static configuration.

This was not up to spec. with the expected documented behaviour: https://www.arduino.cc/en/Reference/WiFi101Config

This patch disables DHCP if ```config``` is used. Also, includes some cleanup to the ```config``` API implementations to remove duplications.