### PR TITLE
Fix issues with WiFiChatServer example

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -204,15 +204,8 @@ int WiFiClient::read()
 {
 	uint8_t b;
 
-	if (!available())
+	if (read(&b, sizeof(b)) == -1) {
 		return -1;
-
-	b = _buffer[_tail++];
-	if (_tail == _head) {
-		_tail = _head = 0;
-		_flag &= ~SOCKET_BUFFER_FLAG_FULL;
-		recv(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
-		m2m_wifi_handle_events(NULL);
 	}
 
 	return b;

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -64,8 +64,8 @@ WiFiClient::WiFiClient(const WiFiClient& other)
 {
 	_socket = other._socket;
 	_flag = other._flag;
-	_head = 0;
-	_tail = 0;
+	_head = other._head;
+	_tail = other._tail;
 	for (int sock = 0; sock < TCP_SOCK_MAX; sock++) {
 		if (WiFi._client[sock] == this)
 			WiFi._client[sock] = 0;

--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -97,6 +97,17 @@ WiFiClient WiFiServer::available(uint8_t* status)
 			*status = 0;
 		}
 		return WiFiClient(((flag & SOCKET_BUFFER_FLAG_SPAWN_SOCKET_MSK) >> SOCKET_BUFFER_FLAG_SPAWN_SOCKET_POS), _socket + 1);
+	} else {
+		WiFiClient *client;
+
+		for (int sock = 0; sock < TCP_SOCK_MAX; sock++) {
+			client = WiFi._client[sock];
+			if (client && client->_flag & SOCKET_BUFFER_FLAG_CONNECTED) {
+				if (((client->_flag >> SOCKET_BUFFER_FLAG_PARENT_SOCKET_POS) & 0xff) == (uint8)_socket) {
+					return *client;
+				}
+			}
+		}
 	}
 
 	return WiFiClient();

--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -93,9 +93,9 @@ WiFiClient WiFiServer::available(uint8_t* status)
 		flag = _flag;
 		_flag &= ~SOCKET_BUFFER_FLAG_SPAWN_SOCKET_MSK;
 		_flag &= ~SOCKET_BUFFER_FLAG_SPAWN;
-		 if (status != NULL) {
+		if (status != NULL) {
 			*status = 0;
-		 }
+		}
 		return WiFiClient(((flag & SOCKET_BUFFER_FLAG_SPAWN_SOCKET_MSK) >> SOCKET_BUFFER_FLAG_SPAWN_SOCKET_POS), _socket + 1);
 	}
 


### PR DESCRIPTION
* ```WiFiServer::available()``` was only returning a connected ```WiFiClient``` instance on new connection. Documentation for API says it should return a client if one is connected (new or existing): https://www.arduino.cc/en/Reference/WiFiServerAvailable
* ```WiFiClient``` copy constructor was not copying over buffer head an tail values.

Also, simplified ```WiFiClient::read``` to delegate to ```WiFiClient::read(...)``` to remove code duplication.