### PR TITLE
Fix connecting to WEP security access points

### DIFF
--- a/src/driver/source/m2m_wifi.c
+++ b/src/driver/source/m2m_wifi.c
@@ -586,7 +586,7 @@ sint8 m2m_wifi_connect_sc(const char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, 
 	{
 		tstrM2mWifiWepParams	* pstrWepParams = (tstrM2mWifiWepParams*)pvAuthInfo;
 		tstrM2mWifiWepParams	*pstrWep = &pstrAuthInfo->uniAuth.strWepInfo;
-		pstrWep->u8KeyIndx =pstrWepParams->u8KeyIndx-1;
+		pstrWep->u8KeyIndx =pstrWepParams->u8KeyIndx;
 
 		if(pstrWep->u8KeyIndx >= WEP_KEY_MAX_INDEX)
 		{

--- a/src/driver/source/m2m_wifi.c
+++ b/src/driver/source/m2m_wifi.c
@@ -594,7 +594,7 @@ sint8 m2m_wifi_connect_sc(const char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, 
 			ret = M2M_ERR_FAIL;
 			goto ERR1;
 		}
-		pstrWep->u8KeySz = pstrWepParams->u8KeySz-1;
+		pstrWep->u8KeySz = pstrWepParams->u8KeySz;
 		if ((pstrWep->u8KeySz != WEP_40_KEY_STRING_SIZE)&& (pstrWep->u8KeySz != WEP_104_KEY_STRING_SIZE))
 		{
 			M2M_ERR("Invalid Wep key length %d\n", pstrWep->u8KeySz);


### PR DESCRIPTION
Resolves issues seen in #17.

 * One was being subtracted from WEP key size.
 * One was being subtracted from WEP key index. WEP key indexes are 1 through 4. However, to maintain the same behaviour as the original WiFI library, use a zero based key index.

cc/ @ThibaultRichard @turkycat