### PR TITLE
Add copy assignment operator to WiFiClient (take 2)

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -71,6 +71,10 @@ void WiFiClient::setMembersAndWiFiCache(const WiFiClient& other)
 	_flag = other._flag;
 	_head = other._head;
 	_tail = other._tail;
+	if (_head > _tail) {
+		memcpy(_buffer + _tail, other._buffer + _tail, (_head - _tail));
+	}
+
 	for (int sock = 0; sock < TCP_SOCK_MAX; sock++) {
 		if (WiFi._client[sock] == this)
 			WiFi._client[sock] = 0;

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -62,6 +62,11 @@ WiFiClient::WiFiClient(uint8_t sock, uint8_t parentsock)
 
 WiFiClient::WiFiClient(const WiFiClient& other)
 {
+	setMembersAndWiFiCache(other);
+}
+
+void WiFiClient::setMembersAndWiFiCache(const WiFiClient& other)
+{
 	_socket = other._socket;
 	_flag = other._flag;
 	_head = other._head;
@@ -284,4 +289,9 @@ uint8_t WiFiClient::status()
 WiFiClient::operator bool()
 {
 	return _socket != -1;
+}
+
+WiFiClient& WiFiClient::operator =(const WiFiClient& other)
+{
+	setMembersAndWiFiCache(other);
 }

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -62,10 +62,10 @@ WiFiClient::WiFiClient(uint8_t sock, uint8_t parentsock)
 
 WiFiClient::WiFiClient(const WiFiClient& other)
 {
-	setMembersAndWiFiCache(other);
+	copyFrom(other);
 }
 
-void WiFiClient::setMembersAndWiFiCache(const WiFiClient& other)
+void WiFiClient::copyFrom(const WiFiClient& other)
 {
 	_socket = other._socket;
 	_flag = other._flag;
@@ -300,7 +300,7 @@ WiFiClient::operator bool()
 
 WiFiClient& WiFiClient::operator =(const WiFiClient& other)
 {
-	setMembersAndWiFiCache(other);
+	copyFrom(other);
 
 	return *this;
 }

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -75,13 +75,16 @@ void WiFiClient::setMembersAndWiFiCache(const WiFiClient& other)
 		if (WiFi._client[sock] == this)
 			WiFi._client[sock] = 0;
 	}
-	WiFi._client[_socket] = this;
-	
-	// Add socket buffer handler:
-	socketBufferRegister(_socket, &_flag, &_head, &_tail, (uint8 *)_buffer);
-	
-	// Enable receive buffer:
-	recv(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
+
+	if (_socket > -1) {
+		WiFi._client[_socket] = this;
+		
+		// Add socket buffer handler:
+		socketBufferRegister(_socket, &_flag, &_head, &_tail, (uint8 *)_buffer);
+		
+		// Enable receive buffer:
+		recv(_socket, _buffer, SOCKET_BUFFER_MTU, 0);
+	}
 
 	m2m_wifi_handle_events(NULL);
 }

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -294,4 +294,6 @@ WiFiClient::operator bool()
 WiFiClient& WiFiClient::operator =(const WiFiClient& other)
 {
 	setMembersAndWiFiCache(other);
+
+	return *this;
 }

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -47,7 +47,6 @@ public:
 	virtual void flush();
 	virtual void stop();
 	virtual uint8_t connected();
-	virtual void setMembersAndWiFiCache(const WiFiClient& other);
 	virtual operator bool();
 	virtual WiFiClient& operator =(const WiFiClient& other);
 
@@ -62,6 +61,7 @@ private:
 	uint8_t	_buffer[SOCKET_BUFFER_TCP_SIZE];
 	int connect(const char* host, uint16_t port, uint8_t opt);
 	int connect(IPAddress ip, uint16_t port, uint8_t opt, const uint8_t *hostname);
+	void copyFrom(const WiFiClient& other);
 
 };
 

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -47,7 +47,9 @@ public:
 	virtual void flush();
 	virtual void stop();
 	virtual uint8_t connected();
+	virtual void setMembersAndWiFiCache(const WiFiClient& other);
 	virtual operator bool();
+	virtual WiFiClient& operator =(const WiFiClient& other);
 
 	using Print::write;
 


### PR DESCRIPTION
Builds upon @turkycat's work from #16 to resolve #15 with the following additions:

 * Add missing return statement to ='s operator
 * Check for valid socket before registering buffer and caching instance
 * Copy buffered data in client
 * Rename ```setMembersAndWiFiCache``` to ```copyFrom```, and make it private

cc @ThibaultRichard 