### PR TITLE
Change NMC1500 ASIC timeout for boot ROM and firmware start back to 2000

### DIFF
--- a/src/driver/source/nmasic.c
+++ b/src/driver/source/nmasic.c
@@ -51,7 +51,7 @@
 #define NMI_INTR_ENABLE				(NMI_INTR_REG_BASE)
 #define GET_UINT32(X,Y)				(X[0+Y] + ((uint32)X[1+Y]<<8) + ((uint32)X[2+Y]<<16) +((uint32)X[3+Y]<<24))
 
-#define TIMEOUT						(0xfffffffful)
+#define TIMEOUT						(2000)
 #define M2M_DISABLE_PS				(0xd0ul)
 
 static uint32 clk_status_reg_adr = 0xf; /* Assume initially it is B0 chip */

--- a/src/driver/source/nmasic.c
+++ b/src/driver/source/nmasic.c
@@ -51,7 +51,11 @@
 #define NMI_INTR_ENABLE				(NMI_INTR_REG_BASE)
 #define GET_UINT32(X,Y)				(X[0+Y] + ((uint32)X[1+Y]<<8) + ((uint32)X[2+Y]<<16) +((uint32)X[3+Y]<<24))
 
+#ifdef ARDUINO
 #define TIMEOUT						(2000)
+#else
+#define TIMEOUT						(0xfffffffful)
+#endif 
 #define M2M_DISABLE_PS				(0xd0ul)
 
 static uint32 clk_status_reg_adr = 0xf; /* Assume initially it is B0 chip */


### PR DESCRIPTION
Resolves #22.

Timeout was changed from to ```0xfffffffful``` (from ```2000``` ) when support for firmware version 19.4.4 was added (https://github.com/arduino-libraries/WiFi101/commit/541b5be9993d03dde9ab3cd55c0c1b713984ad8f#diff-57b01d2f3e2fef366d5fd9f83065c011L53).

cc @ThibaultRichard