### PR TITLE
Support for reading MAC address from firmware 19.3.0

### DIFF
--- a/src/driver/source/nmasic.c
+++ b/src/driver/source/nmasic.c
@@ -674,6 +674,7 @@ sint8 nmi_get_otp_mac_address(uint8 *pu8MacAddr,  uint8 * pu8IsValid)
 	ret = nm_read_reg_with_ret(rNMI_GP_REG_2, &u32RegValue);
 	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
 
+#ifdef ARDUINO
 	if (u32RegValue) {
 		ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
 		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
@@ -683,6 +684,11 @@ sint8 nmi_get_otp_mac_address(uint8 *pu8MacAddr,  uint8 * pu8IsValid)
 		ret = nm_read_reg_with_ret(rNMI_GP_REG_0, &u32RegValue);
 		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
 	}
+#else
+	ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
+	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
+	u32RegValue = strgp.u32Mac_efuse_mib;
+#endif
 
 	if(!EFUSED_MAC(u32RegValue)) {
 		M2M_DBG("Default MAC\n");
@@ -712,6 +718,7 @@ sint8 nmi_get_mac_address(uint8 *pu8MacAddr)
 	ret = nm_read_reg_with_ret(rNMI_GP_REG_2, &u32RegValue);
 	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
 
+#ifdef ARDUINO
 	if (u32RegValue) {
 		ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
 		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
@@ -721,6 +728,11 @@ sint8 nmi_get_mac_address(uint8 *pu8MacAddr)
 		ret = nm_read_reg_with_ret(rNMI_GP_REG_0, &u32RegValue);
 		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
 	}
+#else
+	ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
+	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
+	u32RegValue = strgp.u32Mac_efuse_mib;
+#endif
 
 	u32RegValue &=0x0000ffff;
 	ret = nm_read_block(u32RegValue|0x30000, mac, 6);

--- a/src/driver/source/nmasic.c
+++ b/src/driver/source/nmasic.c
@@ -674,9 +674,15 @@ sint8 nmi_get_otp_mac_address(uint8 *pu8MacAddr,  uint8 * pu8IsValid)
 	ret = nm_read_reg_with_ret(rNMI_GP_REG_2, &u32RegValue);
 	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
 
-	ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
-	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
-	u32RegValue = strgp.u32Mac_efuse_mib;
+	if (u32RegValue) {
+		ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
+		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
+		u32RegValue = strgp.u32Mac_efuse_mib;
+	} else {
+		// firmware version 19.3.0
+		ret = nm_read_reg_with_ret(rNMI_GP_REG_0, &u32RegValue);
+		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
+	}
 
 	if(!EFUSED_MAC(u32RegValue)) {
 		M2M_DBG("Default MAC\n");
@@ -706,9 +712,15 @@ sint8 nmi_get_mac_address(uint8 *pu8MacAddr)
 	ret = nm_read_reg_with_ret(rNMI_GP_REG_2, &u32RegValue);
 	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
 
-	ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
-	if(ret != M2M_SUCCESS) goto _EXIT_ERR;
-	u32RegValue = strgp.u32Mac_efuse_mib;
+	if (u32RegValue) {
+		ret = nm_read_block(u32RegValue|0x30000,(uint8*)&strgp,sizeof(tstrGpRegs));
+		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
+		u32RegValue = strgp.u32Mac_efuse_mib;
+	} else {
+		// firmware version 19.3.0
+		ret = nm_read_reg_with_ret(rNMI_GP_REG_0, &u32RegValue);
+		if(ret != M2M_SUCCESS) goto _EXIT_ERR;
+	}
 
 	u32RegValue &=0x0000ffff;
 	ret = nm_read_block(u32RegValue|0x30000, mac, 6);


### PR DESCRIPTION
If the value of ```rNMI_GP_REG_2``` is 0, use ```rNMI_GP_REG_0``` value to read MAC address. This maintains backward compatibility.

Incompatible change was introduced in: https://github.com/arduino-libraries/WiFi101/commit/541b5be9993d03dde9ab3cd55c0c1b713984ad8f#diff-57b01d2f3e2fef366d5fd9f83065c011R706