### PR TITLE
Allow another library to override PCINT ISR

### DIFF
--- a/src/bsp/source/nm_bsp_arduino_avr.c
+++ b/src/bsp/source/nm_bsp_arduino_avr.c
@@ -61,7 +61,7 @@ uint8_t rx_pin_read()
 }
 
 #if defined(PCINT0_vect)
-ISR(PCINT0_vect)
+__attribute__((weak)) ISR(PCINT0_vect)
 {
 	if (!rx_pin_read() && gpfIsr)
 	{


### PR DESCRIPTION
As per https://github.com/arduino/Arduino/issues/4534, compile fails if using SoftwareSerial and Wifi101 together.
This is due to the redefinition of PCINT0 ISR; since this ISR is only used to handle UNO (and since on UNO the SS-enabled pins 10/11 are already used by SPI), defining the ISR as weak will allow the sketch to compile fine on all platform (and be senseless on UNO)