### PR TITLE
DO NOT MERGE: Fix SSL TX functionality with firmware version 19.3.0

### DIFF
--- a/src/socket/source/socket.c
+++ b/src/socket/source/socket.c
@@ -593,7 +593,11 @@ SOCKET socket(uint16 u16Domain, uint8 u8Type, uint8 u8Flags)
 				{
 					tstrSSLSocketCreateCmd	strSSLCreate;
 					strSSLCreate.sslSock = sock;
+#ifdef ARDUINO
+					pstrSock->u8SSLFlags = SSL_FLAGS_ACTIVE;
+#else
 					pstrSock->u8SSLFlags = SSL_FLAGS_ACTIVE | SSL_FLAGS_NO_TX_COPY;
+#endif
 					SOCKET_REQUEST(SOCKET_CMD_SSL_CREATE, (uint8*)&strSSLCreate, sizeof(tstrSSLSocketCreateCmd), 0, 0, 0);
 				}
 				break;
@@ -804,7 +808,11 @@ sint16 send(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uint16 flags)
 		if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
 		{
 			u8Cmd			= SOCKET_CMD_SSL_SEND;
+#ifdef ARDUINO
+			u16DataOffset	= SSL_TX_PACKET_OFFSET;
+#else
 			u16DataOffset	= gastrSockets[sock].u16DataOffset;
+#endif
 		}
 
 		s16Ret =  SOCKET_REQUEST(u8Cmd|M2M_REQ_DATA_PKT, (uint8*)&strSend, sizeof(tstrSendCmd), pvSendBuffer, u16SendLength, u16DataOffset);


### PR DESCRIPTION
Resolves issues seen in #30.

Firmware version 19.3.0 does not seem to support the ```SSL_FLAGS_NO_TX_COPY``` flag introduced in https://github.com/arduino-libraries/WiFi101/commit/541b5be9993d03dde9ab3cd55c0c1b713984ad8f#diff-7a88c455f56b9ffd95958f8bc670f948L785. Based on the output of ```WiFiSSLClient.ino``` example:

```
HTTP/1.0 400 Bad Request
Content-Length: 54
Content-Type: text/html; charset=UTF-8
Date: Mon, 15 Feb 2016 22:38:02 GMT

<html><title>Error 400 (Bad Request)!!1</title></html>
disconnecting from server.
```

SSL TX functionality is not working with firmware version 19.3.0 but works with 19.4.0.

@ThibaultRichard is this a good way to handle supporting both FW 19.3.0 and 19.4.0? Do you have any other suggestions?