### PR TITLE
Do not define PCINT* interrupt vectors on Mega and make non-weak on other AVR boards

### DIFF
--- a/src/bsp/source/nm_bsp_arduino_avr.c
+++ b/src/bsp/source/nm_bsp_arduino_avr.c
@@ -137,8 +137,8 @@ void attachInterruptMultiArch(uint32_t pin, void *chip_isr, uint32_t mode)
 	gpfIsr = chip_isr;
 
 	// stategy 0 - attach external interrupt to pin (works on 32u4)
-	pin_irq = digitalPinToInterrupt(pin);
-	if (pin_irq == NOT_AN_INTERRUPT) {
+	pin_irq = digitalPinToInterrupt((int)pin);
+	if (pin_irq == (int)NOT_AN_INTERRUPT) {
 		attachInterruptToChangePin(pin);
 		return;
 	}
@@ -151,8 +151,8 @@ void detachInterruptMultiArch(uint32_t pin)
 {
 	int pin_irq;
 
-	pin_irq = digitalPinToInterrupt(pin);
-	if (pin_irq == NOT_AN_INTERRUPT) {
+	pin_irq = digitalPinToInterrupt((int)pin);
+	if (pin_irq == (int)NOT_AN_INTERRUPT) {
 		detachInterruptToChangePin(pin);
 		return;
 	}

--- a/src/bsp/source/nm_bsp_arduino_avr.c
+++ b/src/bsp/source/nm_bsp_arduino_avr.c
@@ -48,6 +48,8 @@
 #include "common/include/nm_common.h"
 #include <Arduino.h>
 
+#define IS_MEGA (defined(ARDUINO_AVR_MEGA) || defined(ARDUINO_AVR_MEGA2560))
+
 static tpfNmBspIsr gpfIsr;
 
 volatile uint8_t *_receivePortRegister;
@@ -59,6 +61,8 @@ uint8_t rx_pin_read()
 {
   return *_receivePortRegister & _receiveBitMask;
 }
+
+#if !IS_MEGA
 
 #if defined(PCINT0_vect)
 ISR(PCINT0_vect)
@@ -81,6 +85,8 @@ ISR(PCINT2_vect, ISR_ALIASOF(PCINT0_vect));
 #if defined(PCINT3_vect)
 ISR(PCINT3_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
+
+#endif // !IS_MEGA
 
 #if defined(TIMER4_OVF_vect)
 ISR(TIMER4_OVF_vect) {

--- a/src/bsp/source/nm_bsp_arduino_avr.c
+++ b/src/bsp/source/nm_bsp_arduino_avr.c
@@ -61,7 +61,7 @@ uint8_t rx_pin_read()
 }
 
 #if defined(PCINT0_vect)
-__attribute__((weak)) ISR(PCINT0_vect)
+ISR(PCINT0_vect)
 {
 	if (!rx_pin_read() && gpfIsr)
 	{
@@ -71,15 +71,15 @@ __attribute__((weak)) ISR(PCINT0_vect)
 #endif
 
 #if defined(PCINT1_vect)
-__attribute__((weak)) ISR(PCINT1_vect, ISR_ALIASOF(PCINT0_vect));
+ISR(PCINT1_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 #if defined(PCINT2_vect)
-__attribute__((weak)) ISR(PCINT2_vect, ISR_ALIASOF(PCINT0_vect));
+ISR(PCINT2_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 #if defined(PCINT3_vect)
-__attribute__((weak)) ISR(PCINT3_vect, ISR_ALIASOF(PCINT0_vect));
+ISR(PCINT3_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 #if defined(TIMER4_OVF_vect)


### PR DESCRIPTION
 * Resolves #38
 * Reverts #29
 * Remove some AVR specific warnings

Tested with a WiFi 101 Shield + Uno, Leonardo, and Mega 2560

cc/ @facchinm 
