### PR TITLE
Add API for creating access point with WEP password

### DIFF
--- a/examples/AP_SimpleWebServer/AP_SimpleWebServer.ino
+++ b/examples/AP_SimpleWebServer/AP_SimpleWebServer.ino
@@ -22,16 +22,18 @@
 int led =  LED_BUILTIN;
 
 char ssid[] = "wifi101-network"; // created AP name
-char pass[] = "hackme";          // (not supported yet)
+char pass[] = "0000000000";      // AP password (needed only for WEP, must be exactly 10 or 26 characters in length)
+int keyIndex = 0;                // your network key Index number (needed only for WEP)
 
 int status = WL_IDLE_STATUS;
 WiFiServer server(80);
 
 void setup() {
-
-  while (!Serial);
-  delay(1000);
-  Serial.begin(9600);      // initialize serial communication
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
 
   Serial.println("Access Point Web Server");
 
@@ -40,17 +42,29 @@ void setup() {
   // check for the presence of the shield:
   if (WiFi.status() == WL_NO_SHIELD) {
     Serial.println("WiFi shield not present");
-    while (true);       // don't continue
+    // don't continue
+    while (true);
   }
 
-  // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
-  Serial.print("Creating Network named: ");
-  Serial.println(ssid);                   // print the network name (SSID);
-  status = WiFi.beginAP(ssid);
+  // print the network name (SSID);
+  Serial.print("Creating access point named: ");
+  Serial.println(ssid);
+
+  // Create WEP network. Change this line if you want to create an open network:
+  if (WiFi.beginAP(ssid, keyIndex, pass) != WL_CONNECTED) {
+    Serial.println("Creating access point failed");
+    // don't continue
+    while (true);
+  }
+
   // wait 10 seconds for connection:
   delay(10000);
-  server.begin();                           // start the web server on port 80
-  printWifiStatus();                        // you're connected now, so print out the status
+
+  // start the web server on port 80
+  server.begin();
+
+  // you're connected now, so print out the status
+  printWifiStatus();
 }
 
 

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -352,10 +352,14 @@ uint8_t WiFiClass::startAP(const char *ssid, uint8_t u8SecType, const void *pvAu
 		init();
 	}
 
+	if (channel == 0) {
+		channel = 1; // channel 1 is the minium channel
+	}
+
 	// Enter Access Point mode:
 	memset(&strM2MAPConfig, 0x00, sizeof(tstrM2MAPConfig));
 	strcpy((char *)&strM2MAPConfig.au8SSID, ssid);
-	strM2MAPConfig.u8ListenChannel = channel;
+	strM2MAPConfig.u8ListenChannel = channel - 1;
 	strM2MAPConfig.u8SecType = u8SecType;
 	strM2MAPConfig.au8DHCPServerIP[0] = 0xC0; /* 192 */
 	strM2MAPConfig.au8DHCPServerIP[1] = 0xA8; /* 168 */

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -104,6 +104,8 @@ public:
 	 */
 	uint8_t beginAP(char *ssid);
 	uint8_t beginAP(char *ssid, uint8_t channel);
+	uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key);
+	uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key, uint8_t channel);
 
 	uint8_t beginProvision(char *ssid, char *url);
 	uint8_t beginProvision(char *ssid, char *url, uint8_t channel);
@@ -142,6 +144,7 @@ private:
 	int _init;
 	char _version[9];
 	uint8_t startConnect(const char *ssid, uint8_t u8SecType, const void *pvAuthInfo);
+	uint8_t startAP(const char *ssid, uint8_t u8SecType, const void *pvAuthInfo, uint8_t channel);
 };
 
 extern WiFiClass WiFi;


### PR DESCRIPTION
As requested in #42.

* Add ``` beginAP(const char *ssid, uint8_t key_idx, const char* key)``` and ```beginAP(const char *ssid, uint8_t key_idx, const char* key, uint8_t channel)``` API's for creating access point with a WEP password.
* Update ```AP_SimpleWebServer.ino``` example to have WEP password
* Correct AP channel off by one error, if ```beginAP``` was called with a channel of 1, AP would be created on channel 2.