### PR TITLE
Call m2m_wifi_handle_events from WiFiClass::status()

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -631,6 +631,9 @@ uint8_t WiFiClass::status()
 	if (!_init) {
 		init();
 	}
+
+	m2m_wifi_handle_events(NULL);
+
 	return _status;
 }
 


### PR DESCRIPTION
For sketches that want to check the WiFi status and re-connect if
disconnected.

Example:
```arduino
#include <WiFi101.h>

char ssid[] = "yourNetwork";     //  your network SSID (name)
char pass[] = "password";  // your network password

void setup() {
  //Initialize serial and wait for port to open:
  Serial.begin(9600);
  while (!Serial) {
    ; // wait for serial port to connect. Needed for native USB port only
  }

  // check for the presence of the shield:
  if (WiFi.status() == WL_NO_SHIELD) {
    Serial.println("WiFi shield not present");
    // don't continue:
    while (true);
  }
}

void loop() {
  if (WiFi.status() != WL_CONNECTED) {
    Serial.print("WiFi not connected, attempting to connect to WPA SSID: ");
    Serial.println(ssid);
    // Connect to WPA/WPA2 network:
    if (WiFi.begin(ssid, pass) == WL_CONNECTED) {
      Serial.println("You're connected to the network");
    } else {
      Serial.println("Network connection failed");
    }
  }

  delay(5000);
}
```

Without this change ```WiFi.status()``` will always return ```WL_CONNECTED``` once connected, even if access point is disconnected later.