### PR TITLE
Add strings.h include for non-AVR platforms

### DIFF
--- a/src/WiFiMdnsResponder.cpp
+++ b/src/WiFiMdnsResponder.cpp
@@ -22,6 +22,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <avr/pgmspace.h>
+#ifndef ARDUINO_ARCH_AVR
+#include <strings.h>
+#endif
 
 #include "Arduino.h"
 #include "WiFiMdnsResponder.h"


### PR DESCRIPTION
Needed for ```strncasecmp``` on some platforms, like the ARC32.

Helps resolve a piece of #51.