### PR TITLE
Support for Teensy

### DIFF
--- a/src/bsp/source/nm_bsp_arduino.c
+++ b/src/bsp/source/nm_bsp_arduino.c
@@ -92,6 +92,9 @@ static void init_chip_pins(void)
 	pinMode(WINC1501_RESET_PIN, OUTPUT);
 	digitalWrite(WINC1501_RESET_PIN, HIGH);
 
+	/* Configure INTN D7 pins as pinput. */
+	pinMode(WINC1501_INTN_PIN, INPUT);
+
 #if defined(WINC1501_CHIP_EN_PIN)
 	/* Configure CHIP_EN as pull-up */
 	pinMode(WINC1501_CHIP_EN_PIN, INPUT_PULLUP);


### PR DESCRIPTION
Resolves #19.

Here are the pin connections I am using with the WiFi101 shield:

| WiFi 101 Shield  | Teensy 3.1 | Other |
| ---------------------- | -------------- | --------|
| IOREF | 3.3V | |
| 5V | | External 5V source |
| GND | GND | |
| MISO (ICSP header) | 12 (DIN) | |
| SCK (ICSP header) | 13  (SCK) | |
| MOSI (ICSP header) | 11 (DOUT) | |
| 8 (SS) | 8 |
| 7 (INTN) | 7 |
| 5 (RST) | 5 |

This is based on the [Arduino-WiFi101-schematic.pdf](http://www.arduino.cc/en/uploads/Main/Arduino-WiFi101-schematic.pdf).

@PaulStoffregen please review. Also, it would be great to avoid having https://github.com/arduino-libraries/WiFi101/commit/1d0d5240c2f31bb8e5cfc48d9373c6d98c399493. This can be done by pulling in https://github.com/arduino/Arduino/commit/e3909b4e2c050213e836f2ca9c132f906bc832b9#diff-f7547b12f3c5fde42e24a2f20a63262f to the Teensy core which @cmaglie introduced in September.

cc/ @cmaglie @facchinm @akash73