### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+language: generic
+env:
+  global:
+    - IDE_VERSION=1.6.8
+  matrix:
+    - BOARD="arduino:avr:uno"
+    - BOARD="arduino:avr:leonardo"
+    - BOARD="arduino:avr:mega:cpu=atmega2560"
+    - BOARD="arduino:sam:arduino_due_x_dbg"
+    - BOARD="arduino:samd:arduino_zero_edbg"
+    - BOARD="arduino:samd:mkr1000"
+    - BOARD="Intel:arc32:arduino_101"
+matrix:
+  allow_failures:
+    - env: BOARD="arduino:avr:leonardo"
+    - env: BOARD="arduino:sam:arduino_due_x_dbg"
+    - env: BOARD="Intel:arc32:arduino_101"
+before_install:
+  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
+  - sleep 3
+  - export DISPLAY=:1.0
+  - wget http://downloads.arduino.cc/arduino-$IDE_VERSION-linux64.tar.xz
+  - tar xf arduino-$IDE_VERSION-linux64.tar.xz
+  - mv arduino-$IDE_VERSION $HOME/arduino-ide
+  - export PATH=$PATH:$HOME/arduino-ide
+  - if [[ "$BOARD" =~ "arduino:sam:" ]]; then
+      arduino --install-boards arduino:sam;
+    fi
+  - if [[ "$BOARD" =~ "arduino:samd:" ]]; then
+      arduino --install-boards arduino:samd;
+    fi
+  - if [[ "$BOARD" =~ "Intel:arc32" ]]; then
+      arduino --install-boards Intel:arc32;
+    fi
+  - buildExampleSketch() { arduino --verbose-build --verify --board $BOARD $PWD/examples/$1/$1.ino; }
+install:
+  - mkdir -p $HOME/Arduino/libraries
+  - ln -s $PWD $HOME/Arduino/libraries/.
+script:
+  - buildExampleSketch AP_SimpleWebServer
+  - buildExampleSketch CheckWifi101FirmwareVersion
+  - buildExampleSketch ConnectNoEncryption
+  - buildExampleSketch ConnectWithWEP
+  - buildExampleSketch ConnectWithWPA
+  - buildExampleSketch FirmwareUpdater
+  - buildExampleSketch MDNS_WiFiWebServer
+  - buildExampleSketch ScanNetworks
+  - buildExampleSketch SimpleWebServerWiFi
+  - buildExampleSketch WiFiChatServer
+  - buildExampleSketch WiFiSSLClient
+  - buildExampleSketch WiFiUdpNtpClient
+  - buildExampleSketch WiFiUdpSendReceiveString
+  - buildExampleSketch WiFiWebClient
+  - buildExampleSketch WiFiWebClientRepeating
+  - buildExampleSketch WiFiWebServer
+

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,7 @@
 = Wifi library for the Arduino Wifi 101 Shield and MKR1000 board =
 
+image:https://travis-ci.org/arduino-libraries/WiFi101.svg?branch=master["Build Status", link="https://travis-ci.org/arduino-libraries/WiFi101"]
+
 This library implements a network driver for devices based
 on the ATMEL WINC1500 wifi module.
 


### PR DESCRIPTION
The Travis CI configuration is currently setup to build all WiFi101 example sketches on the following boards: Uno, Leonardo, Mega, Due, Zero, 101, MKR1000.

The build with fail until #54 is merged. I've also configured "allowed failures" for Due, 101, and Leonardo. We can remove Due and 101 from the list once #51 is resolved. Leonardo is failing because some of the example sketches are too big for the flash space available on the board.