### PR TITLE
Add setPins API to override default WINC1500 pins

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,6 +15,7 @@ Server	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
+setPins	KEYWORD2
 status	KEYWORD2
 connect	KEYWORD2
 connectSSL	KEYWORD2

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -21,6 +21,7 @@
 
 extern "C" {
   #include "bsp/include/nm_bsp.h"
+  #include "bsp/include/nm_bsp_arduino.h"
   #include "socket/include/socket_buffer.h"
   #include "driver/source/nmasic.h"
   #include "driver/include/m2m_periph.h"
@@ -152,6 +153,14 @@ WiFiClass::WiFiClass()
 	_mode = WL_RESET_MODE;
 	_status = WL_NO_SHIELD;
 	_init = 0;
+}
+
+void WiFiClass::setPins(int8_t cs, int8_t irq, int8_t rst, int8_t en)
+{
+	gi8Winc1501CsPin = cs;
+	gi8Winc1501IntnPin = irq;
+	gi8Winc1501ResetPin = rst;
+	gi8Winc1501ChipEnPin = en;
 }
 
 int WiFiClass::init()

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -79,6 +79,8 @@ public:
 
 	WiFiClass();
 
+	void setPins(int8_t cs, int8_t irq, int8_t rst, int8_t en = -1);
+
 	int init();
 	
 	char* firmwareVersion();

--- a/src/bsp/include/nm_bsp_arduino.h
+++ b/src/bsp/include/nm_bsp_arduino.h
@@ -1,0 +1,74 @@
+/**
+ *
+ * \file
+ *
+ * \brief This module contains NMC1500 BSP APIs definitions.
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _NM_BSP_ARDUINO_H_
+#define _NM_BSP_ARDUINO_H_
+
+#include <stdint.h>
+
+#include <Arduino.h>
+
+/*
+ * Arduino variants may redefine those pins.
+ * If no pins are specified the following defaults are used:
+ *  WINC1501_RESET_PIN   - pin 5
+ *  WINC1501_INTN_PIN    - pin 7
+ *  WINC1501_CHIP_EN_PIN - not connected (tied to VCC)
+ */
+#if !defined(WINC1501_RESET_PIN)
+  #define WINC1501_RESET_PIN  5
+#endif
+#if !defined(WINC1501_INTN_PIN)
+  #define WINC1501_INTN_PIN   7
+#endif
+#if !defined(WINC1501_SPI_CS_PIN)
+  #define WINC1501_SPI_CS_PIN 10
+#endif
+#if !defined(WINC1501_CHIP_EN_PIN)
+  #define WINC1501_CHIP_EN_PIN -1
+#endif
+
+extern int8_t gi8Winc1501CsPin;
+extern int8_t gi8Winc1501ResetPin;
+extern int8_t gi8Winc1501IntnPin;
+extern int8_t gi8Winc1501ChipEnPin;
+
+#endif /* _NM_BSP_ARDUINO_H_ */

--- a/src/bsp/source/nm_bsp_arduino.c
+++ b/src/bsp/source/nm_bsp_arduino.c
@@ -43,22 +43,13 @@
  */
 
 #include "bsp/include/nm_bsp.h"
+#include "bsp/include/nm_bsp_arduino.h"
 #include "common/include/nm_common.h"
-#include <Arduino.h>
 
-/*
- * Arduino variants may redefine those pins.
- * If no pins are specified the following defaults are used:
- *  WINC1501_RESET_PIN   - pin 5
- *  WINC1501_INTN_PIN    - pin 7
- *  WINC1501_CHIP_EN_PIN - not connected (tied to VCC)
- */
-#if !defined(WINC1501_RESET_PIN)
-  #define WINC1501_RESET_PIN  5
-#endif
-#if !defined(WINC1501_INTN_PIN)
-  #define WINC1501_INTN_PIN   7
-#endif
+int8_t gi8Winc1501CsPin = WINC1501_SPI_CS_PIN;
+int8_t gi8Winc1501ResetPin = WINC1501_RESET_PIN;
+int8_t gi8Winc1501IntnPin = WINC1501_INTN_PIN;
+int8_t gi8Winc1501ChipEnPin = WINC1501_CHIP_EN_PIN;
 
 static tpfNmBspIsr gpfIsr;
 
@@ -88,17 +79,18 @@ static void chip_isr(void)
  */
 static void init_chip_pins(void)
 {
-	/* Configure RESETN D6 pins as output. */
-	pinMode(WINC1501_RESET_PIN, OUTPUT);
-	digitalWrite(WINC1501_RESET_PIN, HIGH);
+	/* Configure RESETN pin as output. */
+	pinMode(gi8Winc1501ResetPin, OUTPUT);
+	digitalWrite(gi8Winc1501ResetPin, HIGH);
 
-	/* Configure INTN D7 pins as pinput. */
-	pinMode(WINC1501_INTN_PIN, INPUT);
+	/* Configure INTN pins as input. */
+	pinMode(gi8Winc1501IntnPin, INPUT);
 
-#if defined(WINC1501_CHIP_EN_PIN)
-	/* Configure CHIP_EN as pull-up */
-	pinMode(WINC1501_CHIP_EN_PIN, INPUT_PULLUP);
-#endif
+	if (gi8Winc1501ChipEnPin > -1)
+	{
+		/* Configure CHIP_EN as pull-up */
+		pinMode(gi8Winc1501ChipEnPin, INPUT_PULLUP);
+	}
 }
 
 /*
@@ -143,9 +135,9 @@ sint8 nm_bsp_deinit(void)
  */
 void nm_bsp_reset(void)
 {
-	digitalWrite(WINC1501_RESET_PIN, LOW);
+	digitalWrite(gi8Winc1501ResetPin, LOW);
 	nm_bsp_sleep(100);
-	digitalWrite(WINC1501_RESET_PIN, HIGH);
+	digitalWrite(gi8Winc1501ResetPin, HIGH);
 	nm_bsp_sleep(100);
 }
 
@@ -178,7 +170,7 @@ void nm_bsp_sleep(uint32 u32TimeMsec)
 void nm_bsp_register_isr(tpfNmBspIsr pfIsr)
 {
 	gpfIsr = pfIsr;
-	attachInterruptMultiArch(WINC1501_INTN_PIN, chip_isr, FALLING);
+	attachInterruptMultiArch(gi8Winc1501IntnPin, chip_isr, FALLING);
 }
 
 /*
@@ -193,8 +185,8 @@ void nm_bsp_register_isr(tpfNmBspIsr pfIsr)
 void nm_bsp_interrupt_ctrl(uint8 u8Enable)
 {
 	if (u8Enable) {
-		attachInterruptMultiArch(WINC1501_INTN_PIN, chip_isr, FALLING);
+		attachInterruptMultiArch(gi8Winc1501IntnPin, chip_isr, FALLING);
 	} else {
-		detachInterruptMultiArch(WINC1501_INTN_PIN);
+		detachInterruptMultiArch(gi8Winc1501IntnPin);
 	}
 }

--- a/src/bsp/source/nm_bsp_arduino_avr.c
+++ b/src/bsp/source/nm_bsp_arduino_avr.c
@@ -45,8 +45,8 @@
 #ifdef ARDUINO_ARCH_AVR
 
 #include "bsp/include/nm_bsp.h"
+#include "bsp/include/nm_bsp_arduino.h"
 #include "common/include/nm_common.h"
-#include <Arduino.h>
 
 #define IS_MEGA (defined(ARDUINO_AVR_MEGA) || defined(ARDUINO_AVR_MEGA2560))
 

--- a/src/bus_wrapper/source/nm_bus_wrapper_samd21.cpp
+++ b/src/bus_wrapper/source/nm_bus_wrapper_samd21.cpp
@@ -49,18 +49,15 @@
  * Variants may define an alternative SPI instace to use for WiFi101.
  * If not defined the following defaults are used:
  *   WINC1501_SPI    - SPI
- *   WINC1501_CS_PIN - pin 10
  */
 #if !defined(WINC1501_SPI)
   #define WINC1501_SPI SPI
-#endif
-#if !defined(WINC1501_SPI_CS_PIN)
-  #define WINC1501_SPI_CS_PIN 10
 #endif
 
 extern "C" {
 
 #include "bsp/include/nm_bsp.h"
+#include "bsp/include/nm_bsp_arduino.h"
 #include "common/include/nm_common.h"
 #include "bus_wrapper/include/nm_bus_wrapper.h"
 
@@ -93,7 +90,7 @@ static sint8 spi_rw(uint8* pu8Mosi, uint8* pu8Miso, uint16 u16Sz)
 	}
 
 	WINC1501_SPI.beginTransaction(wifi_SPISettings);
-	digitalWrite(WINC1501_SPI_CS_PIN, LOW);
+	digitalWrite(gi8Winc1501CsPin, LOW);
 
 	while (u16Sz) {
 		*pu8Miso = WINC1501_SPI.transfer(*pu8Mosi);
@@ -105,7 +102,7 @@ static sint8 spi_rw(uint8* pu8Mosi, uint8* pu8Miso, uint16 u16Sz)
 			pu8Mosi++;
 	}
 
-	digitalWrite(WINC1501_SPI_CS_PIN, HIGH);
+	digitalWrite(gi8Winc1501CsPin, HIGH);
 	WINC1501_SPI.endTransaction();
 
 	return M2M_SUCCESS;
@@ -129,8 +126,8 @@ sint8 nm_bus_init(void * /* pvInitValue */)
 	WINC1501_SPI.begin();
 	
 	/* Configure CS PIN. */
-	pinMode(WINC1501_SPI_CS_PIN, OUTPUT);
-	digitalWrite(WINC1501_SPI_CS_PIN, HIGH);
+	pinMode(gi8Winc1501CsPin, OUTPUT);
+	digitalWrite(gi8Winc1501CsPin, HIGH);
 
 	/* Reset WINC1500. */
 	nm_bsp_reset();


### PR DESCRIPTION
A proposal to resolve #57.

I've added a ``WiFiClass::setPins(int8_t cs, int8_t irq, int8_t rst, int8_t en)`` API. This API must be called before any other WiFi APIs to take effect.

It currently uses 4 bytes more RAM, I've opted to store the pins as ```int8_t``` to save a few bytes of RAM on AVR. No issues changing to using ```int``` if that would be better.

Here's a size comparison ```ConnectWithWPA``` example sketch (sizes in bytes):

| Board | Before | After | Difference |
| -------- | --------- | ------ | -------------- |
| Uno | 21,470 | 21,528 | 58 |
| Zero | 19,820 | 19,916 | 96 |

cc/ @ladyada @cmaglie @facchinm