### PR TITLE
Add WiFi.end() API

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -492,6 +492,23 @@ void WiFiClass::disconnect()
 	m2m_periph_gpio_set_val(M2M_PERIPH_GPIO4, 1);
 }
 
+void WiFiClass::end()
+{
+	if (_mode == WL_AP_MODE) {
+		m2m_wifi_disable_ap();
+	} else {
+		if (_mode == WL_PROV_MODE) {
+			m2m_wifi_stop_provision_mode();
+		}
+
+		m2m_wifi_disconnect();
+	}
+
+	// WiFi led OFF (rev A then rev B).
+	m2m_periph_gpio_set_val(M2M_PERIPH_GPIO15, 1);
+	m2m_periph_gpio_set_val(M2M_PERIPH_GPIO4, 1);
+}
+
 uint8_t *WiFiClass::macAddress(uint8_t *mac)
 {
 	m2m_wifi_get_mac_address(mac);

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -313,12 +313,12 @@ uint8_t WiFiClass::startConnect(const char *ssid, uint8_t u8SecType, const void 
 	return _status;
 }
 
-uint8_t WiFiClass::beginAP(char *ssid)
+uint8_t WiFiClass::beginAP(const char *ssid)
 {
 	return beginAP(ssid, 1);
 }
 
-uint8_t WiFiClass::beginAP(char *ssid, uint8_t channel)
+uint8_t WiFiClass::beginAP(const char *ssid, uint8_t channel)
 {
 	return startAP(ssid, M2M_WIFI_SEC_OPEN, NULL, channel);
 }

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -118,6 +118,7 @@ public:
 	void config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet);
 
 	void disconnect();
+	void end();
 
 	uint8_t *macAddress(uint8_t *mac);
 

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -102,8 +102,8 @@ public:
 	 * param ssid: Pointer to the SSID string.
 	 * param channel: Wifi channel to use. Valid values are 1-12.
 	 */
-	uint8_t beginAP(char *ssid);
-	uint8_t beginAP(char *ssid, uint8_t channel);
+	uint8_t beginAP(const char *ssid);
+	uint8_t beginAP(const char *ssid, uint8_t channel);
 	uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key);
 	uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key, uint8_t channel);
 


### PR DESCRIPTION
Added a new ```WiFi.end()``` API to stop AP or provision mode. It also performs a disconnect if in non-AP mode.

Related to #61.

Also, add a ```const``` to the ```beginAP``` ```ssid``` argument.