### PR TITLE
Added Ping functionality with ability to resolve names to IPs using m2m_ping_req() and hostByName().

### DIFF
--- a/examples/WiFiPing/WiFiPing.ino
+++ b/examples/WiFiPing/WiFiPing.ino
@@ -1,0 +1,136 @@
+/*
+
+ This example connects to a encrypted Wifi network (WPA/WPA2).
+ Then it prints the  MAC address of the Wifi shield,
+ the IP address obtained, and other network details.
+ Then it continuously pings given IP Address.
+
+ Circuit:
+ * WiFi shield attached / MKR1000
+
+ created 13 July 2010
+ by dlf (Metodo2 srl)
+ modified 13 May 2016
+ by Petar Georgiev
+ */
+#include <SPI.h>
+#include <WiFi101.h>
+
+char ssid[] = "yourNetwork";     //  your network SSID (name)
+char pass[] = "secretPassword";  // your network password
+int status = WL_IDLE_STATUS;     // the Wifi radio's status
+
+String hostName = "www.google.com";
+byte pingResult;
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the presence of the shield:
+  if (WiFi.status() == WL_NO_SHIELD) {
+    Serial.println("WiFi shield not present");
+    // don't continue:
+    while (true);
+  }
+
+  // attempt to connect to Wifi network:
+  while ( status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to WPA SSID: ");
+    Serial.println(ssid);
+    // Connect to WPA/WPA2 network:
+    status = WiFi.begin(ssid, pass);
+
+    // wait 5 seconds for connection:
+    delay(5000);
+  }
+
+  // you're connected now, so print out the data:
+  Serial.print("You're connected to the network");
+  printCurrentNet();
+  printWifiData();
+
+}
+
+void loop() {
+
+  Serial.print("Pinging ");
+  Serial.print(hostName);
+  Serial.print(": ");
+  
+  pingResult = WiFi.ping(hostName);
+  
+  if (pingResult == WL_PING_SUCCESS){
+    Serial.println("SUCCESS");
+  } else {
+    switch (pingResult){
+      case WL_PING_DEST_UNREACHABLE: { Serial.println("Destination host unreachable"); }; break;
+      case WL_PING_TIMEOUT: { Serial.println("Request Timed Out"); }; break;
+      case WL_PING_UNKNOWN_HOST: { Serial.println("Unable to resolve hostname to IP Address"); }; break;
+      case WL_PING_ERROR: { Serial.println("Internal error"); }; break;  
+    };      
+  };
+  
+  delay(3000);
+}
+
+void printWifiData() {
+  // print your WiFi shield's IP address:
+  IPAddress ip = WiFi.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+  Serial.println(ip);
+
+  // print your MAC address:
+  byte mac[6];
+  WiFi.macAddress(mac);
+  Serial.print("MAC address: ");
+  Serial.print(mac[5], HEX);
+  Serial.print(":");
+  Serial.print(mac[4], HEX);
+  Serial.print(":");
+  Serial.print(mac[3], HEX);
+  Serial.print(":");
+  Serial.print(mac[2], HEX);
+  Serial.print(":");
+  Serial.print(mac[1], HEX);
+  Serial.print(":");
+  Serial.println(mac[0], HEX);
+  Serial.println();
+}
+
+void printCurrentNet() {
+  // print the SSID of the network you're attached to:
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  // print the MAC address of the router you're attached to:
+  byte bssid[6];
+  WiFi.BSSID(bssid);
+  Serial.print("BSSID: ");
+  Serial.print(bssid[5], HEX);
+  Serial.print(":");
+  Serial.print(bssid[4], HEX);
+  Serial.print(":");
+  Serial.print(bssid[3], HEX);
+  Serial.print(":");
+  Serial.print(bssid[2], HEX);
+  Serial.print(":");
+  Serial.print(bssid[1], HEX);
+  Serial.print(":");
+  Serial.println(bssid[0], HEX);
+
+  // print the received signal strength:
+  long rssi = WiFi.RSSI();
+  Serial.print("signal strength (RSSI):");
+  Serial.println(rssi);
+
+  // print the encryption type:
+  byte encryption = WiFi.encryptionType();
+  Serial.print("Encryption Type:");
+  Serial.println(encryption, HEX);
+  Serial.println();
+}

--- a/examples/WiFiPing/WiFiPing.ino
+++ b/examples/WiFiPing/WiFiPing.ino
@@ -10,7 +10,7 @@
 
  created 13 July 2010
  by dlf (Metodo2 srl)
- modified 13 May 2016
+ modified 09 June 2016
  by Petar Georgiev
  */
 #include <SPI.h>
@@ -64,14 +64,10 @@ void loop() {
   pingResult = WiFi.ping(hostName);
   
   if (pingResult == WL_PING_SUCCESS){
-    Serial.println("SUCCESS");
+    Serial.println("SUCCESS!");
   } else {
-    switch (pingResult){
-      case WL_PING_DEST_UNREACHABLE: { Serial.println("Destination host unreachable"); }; break;
-      case WL_PING_TIMEOUT: { Serial.println("Request Timed Out"); }; break;
-      case WL_PING_UNKNOWN_HOST: { Serial.println("Unable to resolve hostname to IP Address"); }; break;
-      case WL_PING_ERROR: { Serial.println("Internal error"); }; break;  
-    };      
+	Serial.print("FAILED! Error code: ");
+	Serial.println(pingResult);     
   };
   
   delay(3000);

--- a/examples/WiFiPing/WiFiPing.ino
+++ b/examples/WiFiPing/WiFiPing.ino
@@ -3,7 +3,7 @@
  This example connects to a encrypted Wifi network (WPA/WPA2).
  Then it prints the  MAC address of the Wifi shield,
  the IP address obtained, and other network details.
- Then it continuously pings given IP Address.
+ Then it continuously pings given host specified by IP Address or name.
 
  Circuit:
  * WiFi shield attached / MKR1000
@@ -20,11 +20,12 @@ char ssid[] = "yourNetwork";     //  your network SSID (name)
 char pass[] = "secretPassword";  // your network password
 int status = WL_IDLE_STATUS;     // the Wifi radio's status
 
+// Specify IP address or hostname
 String hostName = "www.google.com";
 byte pingResult;
 
 void setup() {
-  //Initialize serial and wait for port to open:
+  // Initialize serial and wait for port to open:
   Serial.begin(9600);
   while (!Serial) {
     ; // wait for serial port to connect. Needed for native USB port only
@@ -63,11 +64,11 @@ void loop() {
   
   pingResult = WiFi.ping(hostName);
   
-  if (pingResult == WL_PING_SUCCESS){
+  if (pingResult == WL_PING_SUCCESS) {
     Serial.println("SUCCESS!");
   } else {
-	Serial.print("FAILED! Error code: ");
-	Serial.println(pingResult);     
+    Serial.print("FAILED! Error code: ");
+    Serial.println(pingResult);     
   };
   
   delay(3000);

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -146,9 +146,9 @@ public:
 	int hostByName(const char* hostname, IPAddress& result);
 	int hostByName(const String &hostname, IPAddress& result) { return hostByName(hostname.c_str(), result); }
 
-	wl_ping_result_t ping(const char* hostname, uint8_t ttl = 128);
-	wl_ping_result_t ping(const String &hostname, uint8_t ttl = 128);
-	wl_ping_result_t ping(IPAddress host, uint8_t ttl = 128);
+	uint8_t ping(const char* hostname, uint8_t ttl = 128);
+	uint8_t ping(const String &hostname, uint8_t ttl = 128);
+	uint8_t ping(IPAddress host, uint8_t ttl = 128);
 	
 	void refresh(void);
 

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -61,11 +61,13 @@ typedef enum {
 	WL_AP_MODE
 } wl_mode_t;
 
-#define WL_PING_SUCCESS 0
-#define WL_PING_DEST_UNREACHABLE 1
-#define WL_PING_TIMEOUT 2
-#define WL_PING_UNKNOWN_HOST 3
-#define WL_PING_ERROR 4	
+typedef enum {
+	WL_PING_SUCCESS = 0,
+	WL_PING_DEST_UNREACHABLE,
+	WL_PING_TIMEOUT,
+	WL_PING_UNKNOWN_HOST,
+	WL_PING_ERROR
+} wl_ping_result_t;
 
 class WiFiClass
 {
@@ -144,10 +146,9 @@ public:
 	int hostByName(const char* hostname, IPAddress& result);
 	int hostByName(const String &hostname, IPAddress& result) { return hostByName(hostname.c_str(), result); }
 
-	uint8_t ping(const char* hostname, uint8_t ttl = 128);
-	uint8_t ping(const String &hostname, uint8_t ttl = 128);
-	uint8_t ping(IPAddress host, uint8_t ttl = 128);
-	uint8_t pingGateway();
+	wl_ping_result_t ping(const char* hostname, uint8_t ttl = 128);
+	wl_ping_result_t ping(const String &hostname, uint8_t ttl = 128);
+	wl_ping_result_t ping(IPAddress host, uint8_t ttl = 128);
 	
 	void refresh(void);
 

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -61,6 +61,12 @@ typedef enum {
 	WL_AP_MODE
 } wl_mode_t;
 
+#define WL_PING_SUCCESS 0
+#define WL_PING_DEST_UNREACHABLE 1
+#define WL_PING_TIMEOUT 2
+#define WL_PING_UNKNOWN_HOST 3
+#define WL_PING_ERROR 4	
+
 class WiFiClass
 {
 public:
@@ -138,6 +144,11 @@ public:
 	int hostByName(const char* hostname, IPAddress& result);
 	int hostByName(const String &hostname, IPAddress& result) { return hostByName(hostname.c_str(), result); }
 
+	uint8_t ping(const char* hostname, uint8_t ttl = 128);
+	uint8_t ping(const String &hostname, uint8_t ttl = 128);
+	uint8_t ping(IPAddress host, uint8_t ttl = 128);
+	uint8_t pingGateway();
+	
 	void refresh(void);
 
 private:


### PR DESCRIPTION
I propose you a PR that adds ping functions to the library as requested in #67. I Also added an example sketch WiFiPing.
The core function's structure is similar to that of hostByName();

Ping Reply Status constants:
#define WL_PING_SUCCESS 0
#define WL_PING_DEST_UNREACHABLE 1
#define WL_PING_TIMEOUT 2
#define WL_PING_UNKNOWN_HOST 3
#define WL_PING_ERROR 4

Functions:
uint8_t ping(const char* hostname, uint8_t ttl = 128);
uint8_t ping(const String &hostname, uint8_t ttl = 128);
uint8_t ping(IPAddress host, uint8_t ttl = 128);
uint8_t pingGateway();