### PR TITLE
Reset status to idle if WiFi.end() is called in AP mode

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -525,6 +525,8 @@ void WiFiClass::end()
 {
 	if (_mode == WL_AP_MODE) {
 		m2m_wifi_disable_ap();
+
+		_status = WL_IDLE_STATUS;
 	} else {
 		if (_mode == WL_PROV_MODE) {
 			m2m_wifi_stop_provision_mode();


### PR DESCRIPTION
Related to PR #62, specifically https://github.com/arduino-libraries/WiFi101/pull/62#issuecomment-232420214.

The internal status was not reset back to idle, if `WiFi.end()` was called in AP mode.

Tested with the following sketch:
```arduino
#include <WiFi101.h>

char ssid[] = "wifi101-network"; // created AP name


char ssid1[] = "ssid";
char pass1[] = "pass";

void setup() {
  //Initialize serial and wait for port to open:
  Serial.begin(9600);
  while (!Serial) {
    ; // wait for serial port to connect. Needed for native USB port only
  }

  // check for the presence of the shield:
  if (WiFi.status() == WL_NO_SHIELD) {
    Serial.println("WiFi shield not present");
    while (true);       // don't continue
  }

  Serial.println("Access Point Web Server");

  // print the network name (SSID);
  Serial.print("Creating access point named: ");
  Serial.println(ssid);

  Serial.println("WiFi status is:");
  Serial.println(WiFi.status());

  // Create open network. Change this line if you want to create an WEP network:
  if (WiFi.beginAP(ssid) != WL_CONNECTED) {
    Serial.println("Creating access point failed");
    // don't continue
    while (true);
  }

  // wait 10 seconds for connection:
  delay(10000);

  Serial.println("WiFi status is:");
  Serial.println(WiFi.status());

  WiFi.end();

  Serial.println("WiFi status is:");
  Serial.println(WiFi.status());

  // attempt to connect to Wifi network:
  while ( WiFi.status() != WL_CONNECTED) {
    Serial.print("Attempting to connect to Network named: ");
    Serial.println(ssid1);                   // print the network name (SSID);

    // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
    WiFi.begin(ssid1, pass1);
    // wait 10 seconds for connection:
    delay(10000);
  }
}

void loop() {
  Serial.println("WiFi status is:");
  Serial.println(WiFi.status());

  delay(1000);

}
```

