### PR TITLE
Add WiFi.getTime() to retrieve system time from WINC

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -40,6 +40,7 @@ encryptionType	KEYWORD2
 getResult	KEYWORD2
 getSocket	KEYWORD2
 poll	KEYWORD2
+getTime	KEYWORD2
 WiFiClient	KEYWORD2
 WiFiServer	KEYWORD2
 WiFiSSLClient	KEYWORD2

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -156,6 +156,8 @@ public:
 	int ping(const String &hostname, uint8_t ttl = 128);
 	int ping(IPAddress host, uint8_t ttl = 128);
 
+	unsigned long getTime();
+
 	void refresh(void);
 
 	void lowPowerMode(void);


### PR DESCRIPTION
This change requires IDE 1.6.10 for AVR based boards, because the newer version of AVR libc provides `time.h` which is needed for `mktime` to convert a decomposed time into epoch time.

*Note:* the Travis CI build is failing again for the Leonardo board because `MDNS_WiFiWebServer` sketch is too big again for the board. I think it's time to remove this board from the Travis CI build, it is listed as "retired" on Arduino.cc website. 