### PR TITLE
Add new WL_AP_LISTENING and WL_AP_CONNECTED status types for AP mode

### DIFF
--- a/examples/AP_SimpleWebServer/AP_SimpleWebServer.ino
+++ b/examples/AP_SimpleWebServer/AP_SimpleWebServer.ino
@@ -51,7 +51,8 @@ void setup() {
   Serial.println(ssid);
 
   // Create open network. Change this line if you want to create an WEP network:
-  if (WiFi.beginAP(ssid) != WL_CONNECTED) {
+  status = WiFi.beginAP(ssid);
+  if (status != WL_AP_LISTENING) {
     Serial.println("Creating access point failed");
     // don't continue
     while (true);
@@ -69,6 +70,20 @@ void setup() {
 
 
 void loop() {
+  // compare the previous status to the current status
+  if (status != WiFi.status()) {
+    // it has changed update the variable
+    status = WiFi.status();
+
+    if (status == WL_AP_CONNECTED) {
+      // a device has connected to the AP
+      Serial.println("Device connected to AP");
+    } else {
+      // a device has disconnected from the AP, and we are back in listening mode
+      Serial.println("Device disconnected from AP");
+    } 
+  }
+  
   WiFiClient client = server.available();   // listen for incoming clients
 
   if (client) {                             // if you get a client,

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -41,6 +41,8 @@ static void wifi_cb(uint8_t u8MsgType, void *pvMsg)
 
 					// WiFi led ON.
 					m2m_periph_gpio_set_val(M2M_PERIPH_GPIO15, 0);
+				} else if (WiFi._mode == WL_AP_MODE) {
+					WiFi._status = WL_AP_CONNECTED;
 				}
 			} else if (pstrWifiState->u8CurrState == M2M_WIFI_DISCONNECTED) {
 				//SERIAL_PORT_MONITOR.println("wifi_cb: M2M_WIFI_RESP_CON_STATE_CHANGED: DISCONNECTED");
@@ -51,6 +53,8 @@ static void wifi_cb(uint8_t u8MsgType, void *pvMsg)
 						WiFi._submask = 0;
 						WiFi._gateway = 0;
 					}
+				} else if (WiFi._mode == WL_AP_MODE) {
+					WiFi._status = WL_AP_LISTENING;
 				}
 				// WiFi led OFF (rev A then rev B).
 				m2m_periph_gpio_set_val(M2M_PERIPH_GPIO15, 1);
@@ -407,7 +411,7 @@ uint8_t WiFiClass::startAP(const char *ssid, uint8_t u8SecType, const void *pvAu
 		_status = WL_CONNECT_FAILED;
 		return _status;
 	}
-	_status = WL_CONNECTED;
+	_status = WL_AP_LISTENING;
 	_mode = WL_AP_MODE;
 
 	memset(_ssid, 0, M2M_MAX_SSID_LEN);
@@ -527,6 +531,7 @@ void WiFiClass::end()
 		m2m_wifi_disable_ap();
 
 		_status = WL_IDLE_STATUS;
+		_mode = WL_RESET_MODE;
 	} else {
 		if (_mode == WL_PROV_MODE) {
 			m2m_wifi_stop_provision_mode();

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -41,7 +41,9 @@ typedef enum {
 	WL_CONNECTED,
 	WL_CONNECT_FAILED,
 	WL_CONNECTION_LOST,
-	WL_DISCONNECTED
+	WL_DISCONNECTED,
+	WL_AP_LISTENING,
+	WL_AP_CONNECTED
 } wl_status_t;
 
 /* Encryption modes */


### PR DESCRIPTION
Resolves #82.

I've added new status enums to track the connected and listening states in AP mode. As well as added some additional code to the `AP_SimpleWebServer.ino` example sketch to print out when a device connects or disconnects to/from the AP.