### PR TITLE
Close sockets when physical link is disconnected

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -53,6 +53,12 @@ static void wifi_cb(uint8_t u8MsgType, void *pvMsg)
 						WiFi._submask = 0;
 						WiFi._gateway = 0;
 					}
+					// Close sockets to clean state
+					// Clients will need to reconnect once the physical link will be re-established
+					for (int i=0; i < TCP_SOCK_MAX; i++) {
+						if (WiFi._client[i])
+							WiFi._client[i]->stop();
+					}
 				} else if (WiFi._mode == WL_AP_MODE) {
 					WiFi._status = WL_AP_LISTENING;
 				}

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -152,7 +152,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, uint8_t opt, const uint8_t 
 		_socket = -1;
 		return 0;
 	}
-	
+
 	// Wait for connection or timeout:
 	unsigned long start = millis();
 	while (!IS_CONNECTED && millis() - start < 20000) {
@@ -163,6 +163,8 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, uint8_t opt, const uint8_t 
 		_socket = -1;
 		return 0;
 	}
+
+	WiFi._client[_socket] = this;
 
 	return 1;
 }


### PR DESCRIPTION
Closing the tcp sockets when the link goes down is not the best practice, but a bug in Atmel's firmware prevents the automatic reconnection to complete successfully after a couple of days of activity (or in "difficult" environments).

This patch tries to bypass this situation by closing the active tcp sockets if a DISCONNECT is received. In this way, the sketch which calls `while client.connected()` has a chance to exit the loop and reconnect forcibly. 

Please note that this will "kill" any sketch which relies on the usual automatic reconnection behaviour. 
