### PR TITLE
[DO NOT MERGE] Proposal to remove WiFi.beginProvision(...) and WiFi.provisioned()

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -96,27 +96,6 @@ static void wifi_cb(uint8_t u8MsgType, void *pvMsg)
 		}
 		break;
 
-		case M2M_WIFI_RESP_PROVISION_INFO:
-		{
-			tstrM2MProvisionInfo *pstrProvInfo = (tstrM2MProvisionInfo *)pvMsg;
-			//SERIAL_PORT_MONITOR.println("wifi_cb: M2M_WIFI_RESP_PROVISION_INFO");
-
-			if (pstrProvInfo->u8Status == M2M_SUCCESS) {
-				memset(WiFi._ssid, 0, M2M_MAX_SSID_LEN);
-				memcpy(WiFi._ssid, (char *)pstrProvInfo->au8SSID, strlen((char *)pstrProvInfo->au8SSID));
-				WiFi._mode = WL_STA_MODE;
-				WiFi._localip = 0;
-				WiFi._submask = 0;
-				WiFi._gateway = 0;
-				m2m_wifi_connect((char *)pstrProvInfo->au8SSID, strlen((char *)pstrProvInfo->au8SSID),
-						pstrProvInfo->u8SecType, pstrProvInfo->au8Password, M2M_WIFI_CH_ALL);
-			} else {
-				WiFi._status = WL_CONNECT_FAILED;
-				//SERIAL_PORT_MONITOR.println("wifi_cb: Provision failed.\r\n");
-			}
-		}
-		break;
-
 		case M2M_WIFI_RESP_SCAN_DONE:
 		{
 			tstrM2mScanDone *pstrInfo = (tstrM2mScanDone *)pvMsg;
@@ -428,60 +407,6 @@ uint8_t WiFiClass::startAP(const char *ssid, uint8_t u8SecType, const void *pvAu
 	return _status;
 }
 
-uint8_t WiFiClass::beginProvision(char *ssid, char *url)
-{
-	return beginProvision(ssid, url, 1);
-}
-
-uint8_t WiFiClass::beginProvision(char *ssid, char *url, uint8_t channel)
-{
-	tstrM2MAPConfig strM2MAPConfig;
-
-	if (!_init) {
-		init();
-	}
-
-	// Enter Provision mode:
-	memset(&strM2MAPConfig, 0x00, sizeof(tstrM2MAPConfig));
-	strcpy((char *)&strM2MAPConfig.au8SSID, ssid);
-	strM2MAPConfig.u8ListenChannel = channel;
-	strM2MAPConfig.u8SecType = M2M_WIFI_SEC_OPEN;
-	strM2MAPConfig.u8SsidHide = SSID_MODE_VISIBLE;
-	strM2MAPConfig.au8DHCPServerIP[0] = 0xC0; /* 192 */
-	strM2MAPConfig.au8DHCPServerIP[1] = 0xA8; /* 168 */
-	strM2MAPConfig.au8DHCPServerIP[2] = 0x01; /* 1 */
-	strM2MAPConfig.au8DHCPServerIP[3] = 0x01; /* 1 */
-
-	if (m2m_wifi_start_provision_mode((tstrM2MAPConfig *)&strM2MAPConfig, url, 1) < 0) {
-		_status = WL_CONNECT_FAILED;
-		return _status;
-	}
-	_status = WL_CONNECTED;
-	_mode = WL_PROV_MODE;
-
-	memset(_ssid, 0, M2M_MAX_SSID_LEN);
-	memcpy(_ssid, ssid, strlen(ssid));
-	m2m_memcpy((uint8 *)&_localip, (uint8 *)&strM2MAPConfig.au8DHCPServerIP[0], 4);
-	_submask = 0x00FFFFFF;
-	_gateway = _localip;
-
-	// WiFi led ON (rev A then rev B).
-	m2m_periph_gpio_set_val(M2M_PERIPH_GPIO15, 0);
-	m2m_periph_gpio_set_val(M2M_PERIPH_GPIO4, 0);
-
-	return _status;
-}
-
-uint32_t WiFiClass::provisioned()
-{
-	if (_mode == WL_STA_MODE) {
-		return 1;
-	}
-	else {
-		return 0;
-	}
-}
-
 void WiFiClass::config(IPAddress local_ip)
 {
 	config(local_ip, (uint32_t)0);
@@ -534,10 +459,6 @@ void WiFiClass::end()
 		_status = WL_IDLE_STATUS;
 		_mode = WL_RESET_MODE;
 	} else {
-		if (_mode == WL_PROV_MODE) {
-			m2m_wifi_stop_provision_mode();
-		}
-
 		m2m_wifi_disconnect();
 	}
 

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -59,7 +59,6 @@ enum wl_enc_type {  /* Values map to 802.11 encryption suites... */
 typedef enum {
 	WL_RESET_MODE = 0,
 	WL_STA_MODE,
-	WL_PROV_MODE,
 	WL_AP_MODE
 } wl_mode_t;
 
@@ -118,11 +117,6 @@ public:
 	uint8_t beginAP(const char *ssid, uint8_t channel);
 	uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key);
 	uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key, uint8_t channel);
-
-	uint8_t beginProvision(char *ssid, char *url);
-	uint8_t beginProvision(char *ssid, char *url, uint8_t channel);
-
-	uint32_t provisioned();
 
 	void config(IPAddress local_ip);
 	void config(IPAddress local_ip, IPAddress dns_server);


### PR DESCRIPTION
There is currently support for provision mode in the library, however we don't include any examples or documentation for it.

After trying it out in #93, I don't think this functionality is not very useful. Here's how it works:
1. You call `WiFi.beginProvision(ssid, url)` to start provision mode. This will cause the WINC1500 to create an AP named `ssid`.
2. When you connect to the SSID, you can configure a new SSID, password, device name for a real access point via a web page.
3. Once configured, the WINC1500 will not be in AP mode anymore, but will try to connect to the AP settings from the previous step.

<img width="1012" alt="screen shot 2016-09-06 at 11 36 05 am" src="https://cloud.githubusercontent.com/assets/1163840/18282092/83b84806-742d-11e6-8892-5bc7abc00d06.png">

I don't think this is useful functionality, because every time the board is power cycled you'll have to re-provision the AP settings.

What do others think?
