### PR TITLE
Add new WL_AP_FAILED type for failed AP creation result

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -415,7 +415,7 @@ uint8_t WiFiClass::startAP(const char *ssid, uint8_t u8SecType, const void *pvAu
 	}
 
 	if (m2m_wifi_enable_ap(&strM2MAPConfig) < 0) {
-		_status = WL_CONNECT_FAILED;
+		_status = WL_AP_FAILED;
 		return _status;
 	}
 	_status = WL_AP_LISTENING;

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -43,7 +43,8 @@ typedef enum {
 	WL_CONNECTION_LOST,
 	WL_DISCONNECTED,
 	WL_AP_LISTENING,
-	WL_AP_CONNECTED
+	WL_AP_CONNECTED,
+	WL_AP_FAILED
 } wl_status_t;
 
 /* Encryption modes */


### PR DESCRIPTION
Additional enum to go with #85, using `WL_CONNECT_FAILED` for failure was inconsistent.