### PR TITLE
Ping functions now return Round Trip Time (RTT) on success or negative error codes on failure

### DIFF
--- a/examples/WiFiPing/WiFiPing.ino
+++ b/examples/WiFiPing/WiFiPing.ino
@@ -63,22 +63,28 @@ void loop() {
 
   pingResult = WiFi.ping(hostName);
 
-  if (pingResult == WL_PING_SUCCESS) {
-    Serial.println("SUCCESS!");
+  if (pingResult >= 0) {
+    Serial.print("SUCCESS! RTT = ");
+    Serial.println(pingResult);
   } else {
     Serial.print("FAILED! Error code: ");
     Serial.println(pingResult);
   }
 
-  delay(3000);
+  delay(1000);
 }
 
 void printWifiData() {
   // print your WiFi shield's IP address:
   IPAddress ip = WiFi.localIP();
-  Serial.print("IP Address: ");
+  Serial.print("IP address : ");
   Serial.println(ip);
-  Serial.println(ip);
+
+  Serial.print("Subnet mask: ");
+  Serial.println((IPAddress)WiFi.subnetMask()); 
+
+  Serial.print("Gateway IP : ");
+  Serial.println((IPAddress)WiFi.gatewayIP());
 
   // print your MAC address:
   byte mac[6];
@@ -121,12 +127,12 @@ void printCurrentNet() {
 
   // print the received signal strength:
   long rssi = WiFi.RSSI();
-  Serial.print("signal strength (RSSI):");
+  Serial.print("signal strength (RSSI): ");
   Serial.println(rssi);
 
   // print the encryption type:
   byte encryption = WiFi.encryptionType();
-  Serial.print("Encryption Type:");
+  Serial.print("Encryption Type: ");
   Serial.println(encryption, HEX);
   Serial.println();
 }

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -159,22 +159,22 @@ static void resolve_cb(uint8_t * /* hostName */, uint32_t hostIp)
 	WiFi._resolve = hostIp;
 }
 
-static void ping_cb(uint32 u32IPAddr, uint32 /*u32RTT*/, uint8 u8ErrorCode)
+static void ping_cb(uint32 u32IPAddr, uint32 u32RTT, uint8 u8ErrorCode)
 {
 	if (PING_ERR_SUCCESS == u8ErrorCode) {
 		// Ensure this ICMP reply comes from requested IP address
 		if (WiFi._resolve == u32IPAddr) {
-			WiFi._resolve = WL_PING_SUCCESS;
+			WiFi._resolve = (uint32_t)u32RTT;
 		} else {
 			// Another network device replied to the our ICMP request
-			WiFi._resolve = WL_PING_DEST_UNREACHABLE;
+			WiFi._resolve = (uint32_t)WL_PING_DEST_UNREACHABLE;
 		}
 	} else if (PING_ERR_DEST_UNREACH == u8ErrorCode) {
-		WiFi._resolve = WL_PING_DEST_UNREACHABLE;
+		WiFi._resolve = (uint32_t)WL_PING_DEST_UNREACHABLE;
 	} else if (PING_ERR_TIMEOUT == u8ErrorCode) {
-		WiFi._resolve = WL_PING_TIMEOUT;
+		WiFi._resolve = (uint32_t)WL_PING_TIMEOUT;
 	} else {
-		WiFi._resolve = WL_PING_ERROR;
+		WiFi._resolve = (uint32_t)WL_PING_ERROR;
 	}
 }
 
@@ -797,7 +797,7 @@ void WiFiClass::noLowPowerMode(void)
 	m2m_wifi_set_sleep_mode(M2M_NO_PS, false);
 }
 
-uint8_t WiFiClass::ping(const char* hostname, uint8_t ttl)
+int WiFiClass::ping(const char* hostname, uint8_t ttl)
 {
 	IPAddress ip;
 
@@ -808,12 +808,12 @@ uint8_t WiFiClass::ping(const char* hostname, uint8_t ttl)
 	}
 }
 
-uint8_t WiFiClass::ping(const String &hostname, uint8_t ttl)
+int WiFiClass::ping(const String &hostname, uint8_t ttl)
 {
 	return ping(hostname.c_str(), ttl);
 }
 
-uint8_t WiFiClass::ping(IPAddress host, uint8_t ttl)
+int WiFiClass::ping(IPAddress host, uint8_t ttl)
 {
 	// Network led ON (rev A then rev B).
 	m2m_periph_gpio_set_val(M2M_PERIPH_GPIO16, 0);
@@ -843,7 +843,7 @@ uint8_t WiFiClass::ping(IPAddress host, uint8_t ttl)
 	if (_resolve == dstHost) {
 		return WL_PING_TIMEOUT;
 	} else {
-		return _resolve;
+		return (int)_resolve;
 	}
 }
 

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -65,11 +65,10 @@ typedef enum {
 } wl_mode_t;
 
 typedef enum {
-	WL_PING_SUCCESS = 0,
-	WL_PING_DEST_UNREACHABLE,
-	WL_PING_TIMEOUT,
-	WL_PING_UNKNOWN_HOST,
-	WL_PING_ERROR
+	WL_PING_DEST_UNREACHABLE = -1,
+	WL_PING_TIMEOUT = -2,
+	WL_PING_UNKNOWN_HOST = -3,
+	WL_PING_ERROR = -4
 } wl_ping_result_t;
 
 class WiFiClass
@@ -152,9 +151,9 @@ public:
 	int hostByName(const char* hostname, IPAddress& result);
 	int hostByName(const String &hostname, IPAddress& result) { return hostByName(hostname.c_str(), result); }
 
-	uint8_t ping(const char* hostname, uint8_t ttl = 128);
-	uint8_t ping(const String &hostname, uint8_t ttl = 128);
-	uint8_t ping(IPAddress host, uint8_t ttl = 128);
+	int ping(const char* hostname, uint8_t ttl = 128);
+	int ping(const String &hostname, uint8_t ttl = 128);
+	int ping(IPAddress host, uint8_t ttl = 128);
 
 	void refresh(void);
 


### PR DESCRIPTION
As proposed in https://github.com/arduino-libraries/WiFi101/pull/68#issuecomment-246704564 all ping functions return:

1. on success: RTT (values >= 0)
2. on failure: negative values

wl_ping_result_t was updated to:

```
typedef enum {
	WL_PING_DEST_UNREACHABLE = -1,
	WL_PING_TIMEOUT = -2,
	WL_PING_UNKNOWN_HOST = -3,
	WL_PING_ERROR = -4
} wl_ping_result_t;
```

WiFiPing example was updated also.
