### PR TITLE
Backwards compatibility for older AVR core versions

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -17,12 +17,20 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if defined(ARDUINO_ARCH_AVR) && (__AVR_LIBC_MAJOR__ < 2)
+#ifdef ARDUINO_ARCH_AVR
+#include <avr/version.h>
+#if (__AVR_LIBC_MAJOR__ < 2)
 #define WIFI_101_NO_TIME_H
+#endif
 #endif
 
 #ifndef WIFI_101_NO_TIME_H
 #include <time.h>
+#endif
+
+#if !defined(_TIME_H_) && !defined(TIME_H)
+// another library overrided the time.h header
+#define WIFI_101_NO_TIME_H
 #endif
 
 #include "WiFi101.h"
@@ -919,6 +927,7 @@ int WiFiClass::ping(IPAddress host, uint8_t ttl)
 uint32_t WiFiClass::getTime()
 {
 #ifdef WIFI_101_NO_TIME_H
+	#warning "No system <time.h> header included, WiFi.getTime() will always return 0"
 	return 0;
 #else
 	tstrSystemTime systemTime;

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -17,7 +17,13 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#if defined(ARDUINO_ARCH_AVR) && (__AVR_LIBC_MAJOR__ < 2)
+#define WIFI_101_NO_TIME_H
+#endif
+
+#ifndef WIFI_101_NO_TIME_H
 #include <time.h>
+#endif
 
 #include "WiFi101.h"
 
@@ -912,6 +918,9 @@ int WiFiClass::ping(IPAddress host, uint8_t ttl)
 
 uint32_t WiFiClass::getTime()
 {
+#ifdef WIFI_101_NO_TIME_H
+	return 0;
+#else
 	tstrSystemTime systemTime;
 
 	_resolve = (uint32_t)&systemTime;
@@ -946,6 +955,7 @@ uint32_t WiFiClass::getTime()
 	}
 
 	return t;
+#endif
 }
 
 WiFiClass WiFi;


### PR DESCRIPTION
They do not have time.h. Resolves #111.

cc/ @drp0.
