### PR TITLE
Fix invalid pointer condition with WiFi.RSSI(pos), WiFi.SSID(pos), and WiFi.encryptionType(pos)

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -765,7 +765,12 @@ int32_t WiFiClass::RSSI(uint8_t pos)
 	}
 
 	_status = tmp;
-	return _resolve;
+
+	int32_t rssi = _resolve;
+
+	_resolve = 0;
+
+	return rssi;
 }
 
 uint8_t WiFiClass::encryptionType()

--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -745,6 +745,8 @@ char* WiFiClass::SSID(uint8_t pos)
 	}
 
 	_status = tmp;
+	_resolve = 0;
+
 	return _scan_ssid;
 }
 
@@ -804,6 +806,8 @@ uint8_t WiFiClass::encryptionType(uint8_t pos)
 	}
 
 	_status = tmp;
+	_resolve = 0;
+
 	return _scan_auth;
 }
 


### PR DESCRIPTION
Related to #117.

cc/ @bcraigie