### PR TITLE
Make WiFi.getTime() return 0 if WINC1500 hasn't synced time

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -988,7 +988,7 @@ uint32_t WiFiClass::getTime()
 
 	time_t t = -1;
 
-	if (_resolve == 0) {
+	if (_resolve == 0 && systemTime.u16Year > 0) {
 		struct tm tm;
 
 		tm.tm_year = systemTime.u16Year - 1900;


### PR DESCRIPTION
Resolves #125.

cc/ @tonywhitfort @drp0