### PR TITLE
Correct beginMulticast method name

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,7 +28,7 @@ connected	KEYWORD2
 begin	KEYWORD2
 beginProvision	KEYWORD2
 beginOrProvision	KEYWORD2
-beginMulti	KEYWORD2
+beginMulticast	KEYWORD2
 disconnect	KEYWORD2
 macAddress	KEYWORD2
 localIP	KEYWORD2

--- a/src/WiFiMDNSResponder.cpp
+++ b/src/WiFiMDNSResponder.cpp
@@ -106,7 +106,7 @@ bool WiFiMDNSResponder::begin(const char* _name, uint32_t _ttlSeconds)
 
   // Open the MDNS UDP listening socket on port 5353 with multicast address
   // 224.0.0.251 (0xE00000FB)
-  if (!udpSocket.beginMulti(IPAddress(224, 0, 0, 251), 5353)) {
+  if (!udpSocket.beginMulticast(IPAddress(224, 0, 0, 251), 5353)) {
     return false;
   }
 

--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -94,7 +94,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
 	return 1;
 }
 
-uint8_t WiFiUDP::beginMulti(IPAddress ip, uint16_t port)
+uint8_t WiFiUDP::beginMulticast(IPAddress ip, uint16_t port)
 {
 	uint32_t multiIp = ip;
 

--- a/src/WiFiUdp.h
+++ b/src/WiFiUdp.h
@@ -40,7 +40,8 @@ private:
 public:
   WiFiUDP();  // Constructor
   virtual uint8_t begin(uint16_t);	// initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
-  virtual uint8_t beginMulti(IPAddress, uint16_t);  // initialize, start listening on specified multicast IP address and port. Returns 1 if successful, 0 if there are no sockets available to use
+  virtual uint8_t beginMulticast(IPAddress, uint16_t);  // initialize, start listening on specified multicast IP address and port. Returns 1 if successful, 0 if there are no sockets available to use
+  virtual uint8_t beginMulti(IPAddress ip, uint16_t port) { return beginMulticast(ip, port); }
   virtual void stop();  // Finish with the UDP socket
 
   // Sending UDP packets


### PR DESCRIPTION
Related to https://github.com/arduino/Arduino/pull/5796.

The Ethernet UDP class name has `beginMulticast` not `beginMulti`.