### PR TITLE
Add ability to retrieve scanned AP's BSSID and channel

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -39,6 +39,7 @@ BSSID		KEYWORD2
 APClientMacAddress	KEYWORD2
 RSSI	KEYWORD2
 encryptionType	KEYWORD2
+channel	KEYWORD2
 provisioned	KEYWORD2
 getResult	KEYWORD2
 getSocket	KEYWORD2

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -148,6 +148,7 @@ public:
 	char* SSID(uint8_t pos);
 	int32_t RSSI(uint8_t pos);
 	uint8_t encryptionType(uint8_t pos);
+	uint8_t* BSSID(uint8_t pos, uint8_t* bssid);
 
 	uint8_t status();
 

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -86,6 +86,7 @@ public:
 	wl_status_t _status;
 	char _scan_ssid[M2M_MAX_SSID_LEN];
 	uint8_t _scan_auth;
+	uint8_t _scan_channel;
 	char _ssid[M2M_MAX_SSID_LEN];
 	WiFiClient *_client[TCP_SOCK_MAX];
 
@@ -149,6 +150,7 @@ public:
 	int32_t RSSI(uint8_t pos);
 	uint8_t encryptionType(uint8_t pos);
 	uint8_t* BSSID(uint8_t pos, uint8_t* bssid);
+	uint8_t channel(uint8_t pos);
 
 	uint8_t status();
 


### PR DESCRIPTION
As requested in #141 (an alternative to #142).

cc/ @gmag11