### PR TITLE
Added a getter method for the destination IP address.

### DIFF
--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -287,3 +287,8 @@ uint16_t  WiFiUDP::remotePort()
 {
 	return _rcvPort;
 }
+
+IPAddress  WiFiUDP::destinationIP()
+{
+	return _sndIP;
+}

--- a/src/WiFiUdp.h
+++ b/src/WiFiUdp.h
@@ -84,6 +84,8 @@ public:
   // Return the port of the host who sent the current incoming packet
   virtual uint16_t remotePort();
 
+  // Return the IP address of the destination host. Useful when beginPacket(const char *host, uint16_t port) method is used.
+  virtual IPAddress destinationIP();
 };
 
 #endif /* WIFIUDP_H */


### PR DESCRIPTION
This is useful when the beginPacket method is called with the hostname parameter.

The method should also be added to Arduino/hardware/arduino/avr/cores/arduino/Udp.h and to Arduino/libraries/WiFi/src/WiFiUdp.h.