### PR TITLE
Fix typo in WiFiWebServer example

### DIFF
--- a/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/examples/WiFiWebServer/WiFiWebServer.ino
@@ -45,7 +45,7 @@ void setup() {
   }
 
   // attempt to connect to WiFi network:
-  while ( status != WL_CONNECTED) {
+  while (status != WL_CONNECTED) {
     Serial.print("Attempting to connect to SSID: ");
     Serial.println(ssid);
     // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
@@ -110,7 +110,7 @@ void loop() {
 
     // close the connection:
     client.stop();
-    Serial.println("client disonnected");
+    Serial.println("client disconnected");
   }
 }
 


### PR DESCRIPTION
From "disonnected" to "disconnected".

Also, remove an additional space that is right after the loop condition opening parenthesis, in line 48.