### PR TITLE
Add ability to retrieve remote IP and port of WiFiClient

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -208,3 +208,21 @@ bool WiFiClient::operator!=(const WiFiClient &other) const
 {
 	return (_socket != other._socket);
 }
+
+IPAddress WiFiClient::remoteIP()
+{
+	if (_socket == -1) {
+		return IPAddress(0, 0, 0, 0);
+	}
+
+	return WiFiSocket.remoteIP(_socket);
+}
+
+uint16_t WiFiClient::remotePort()
+{
+	if (_socket == -1) {
+		return 0;
+	}
+
+	return _htons(WiFiSocket.remotePort(_socket));
+}

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -55,6 +55,9 @@ public:
 
 	using Print::write;
 
+	virtual IPAddress remoteIP();
+	virtual uint16_t remotePort();
+
 private:
 	SOCKET _socket;
 


### PR DESCRIPTION
Was discussed in https://github.com/arduino-libraries/WiFi101/issues/40, with PR #204 the infrastructure to store the value is present and used for UDP sockets. These change make it accessible to TCP sockets.