### PR TITLE
Fixes for issue #214

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -806,6 +806,10 @@ uint8_t* WiFiClass::remoteMacAddress(uint8_t* remoteMacAddress)
 
 int32_t WiFiClass::RSSI()
 {
+	if (_mode == WL_RESET_MODE) {
+		return -100;
+	}
+
 	// Clear pending events:
 	m2m_wifi_handle_events(NULL);
 

--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -46,7 +46,7 @@ uint8_t WiFiServer::begin(uint8_t opt)
 	addr.sin_port = _htons(_port);
 	addr.sin_addr.s_addr = 0;
 
-	if (_socket != -1) {
+	if (_socket != -1 && WiFiSocket.listening(_socket)) {
 		WiFiSocket.close(_socket);
 		_socket = -1;
 	}

--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -46,6 +46,11 @@ uint8_t WiFiServer::begin(uint8_t opt)
 	addr.sin_port = _htons(_port);
 	addr.sin_addr.s_addr = 0;
 
+	if (_socket != -1) {
+		WiFiSocket.close(_socket);
+		_socket = -1;
+	}
+
 	// Open TCP server socket.
 	if ((_socket = WiFiSocket.create(AF_INET, SOCK_STREAM, opt)) < 0) {
 		return 0;
@@ -72,6 +77,10 @@ WiFiClient WiFiServer::available(uint8_t* status)
 {
 	if (status != NULL) {
 		*status = 0;
+	}
+
+	if (_socket != -1 && !WiFiSocket.listening(_socket)) {
+		_socket = -1;
 	}
 
 	if (_socket != -1) {

--- a/src/utility/WiFiSocket.cpp
+++ b/src/utility/WiFiSocket.cpp
@@ -165,6 +165,13 @@ uint8 WiFiSocketClass::connected(SOCKET sock)
 	return (_info[sock].state == SOCKET_STATE_CONNECTED);
 }
 
+uint8 WiFiSocketClass::listening(SOCKET sock)
+{
+	m2m_wifi_handle_events(NULL);
+
+	return (_info[sock].state == SOCKET_STATE_LISTENING);
+}
+
 int WiFiSocketClass::available(SOCKET sock)
 {
 	m2m_wifi_handle_events(NULL);

--- a/src/utility/WiFiSocket.h
+++ b/src/utility/WiFiSocket.h
@@ -39,6 +39,7 @@ public:
   sint8 setopt(SOCKET socket, uint8 u8Level, uint8 option_name, const void *option_value, uint16 u16OptionLen);
   sint8 connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen);
   uint8 connected(SOCKET sock);
+  uint8 listening(SOCKET sock);
   int available(SOCKET sock);
   int peek(SOCKET sock);
   int read(SOCKET sock, uint8_t* buf, size_t size);


### PR DESCRIPTION
Fixes #214.

The following sketch based on @BrunDog's sketch can be used to reproduce the issue on a MKR1000:

```arduino
#include <SPI.h>
#include <WiFi101.h>

char ssid[] = "SSID";
char pass[] = "PASS";
//IPAddress IP = {192, 168, 1, 240};
int status = WL_IDLE_STATUS;
int restartLevel = 0;

WiFiServer server(23);

boolean alreadyConnected = false;
unsigned long oldtime;

void setup() {
  //  WiFi.setPins(8, 7, 4, 2);
  Serial.begin(115200);
  pinMode(LED_BUILTIN, OUTPUT);
  while (!Serial) {
    ;
  }
  initNetwork();
}


void loop() {
  WiFiClient client = server.available();

  if (client) {
    if (!alreadyConnected) {
      client.flush();
      Serial.println("We have a new client");
      client.println("Hello, client!");
      alreadyConnected = true;
    }

    if (client.available() > 0) {
      char thisChar = client.read();
      server.write(thisChar);
      Serial.write(thisChar);
      if (thisChar == '!') restartLevel = 1;
    }
  }

  
  if ((millis() - oldtime) >= 3000) {
    Serial.println("tick");
    
    printWiFiStatus();
    if (digitalRead(LED_BUILTIN)) digitalWrite(LED_BUILTIN, LOW);
    else digitalWrite(LED_BUILTIN, HIGH);
    
    if (restartLevel) restartSequence();
    oldtime = millis();
  }
}


void printWiFiStatus() {
Serial.println("printWiFiStatus");
  
  Serial.print("SSID: ");
  Serial.println(WiFi.SSID());
  IPAddress ipx = WiFi.localIP();
  Serial.print("IP Address: ");
  Serial.println(ipx);
  long rssi = WiFi.RSSI();
  Serial.print("RSSI:");
  Serial.print(rssi);
  Serial.println(" dBm");
}

void initNetwork() {
  //  WiFi.setPins(8, 7, 4, 2);
  //  WiFi.config(IP);
  if (WiFi.status() == WL_NO_SHIELD) {
    Serial.println("No WiFi hardware");
    while (true);
  }

  status = WiFi.begin(ssid, pass);
  while ( status != WL_CONNECTED) {
    Serial.print("Connecting: ");
    Serial.println(ssid);

    status = WiFi.begin(ssid, pass);
    delay(10000);
  }
  server.begin();
  printWiFiStatus();
}


void restartSequence() {
  switch (restartLevel) {
    case 1:
      WiFi.disconnect();
      restartLevel = 2;
      Serial.println("WiFi Disconnected");
      break;
    case 2:
      WiFi.end();
      restartLevel = 3;
      Serial.println("WiFi Ended");
      break;
    case 3:
      Serial.println("WiFi init");
      initNetwork();
      restartLevel = 0;
      break;
  }
}
```