### PR TITLE
Fix Due not working

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -288,9 +288,11 @@ int WiFiClass::init()
 	ret = m2m_wifi_init(&param);
 	if (M2M_SUCCESS != ret && M2M_ERR_FW_VER_MISMATCH != ret) {
 #ifdef CONF_PERIPH
-		// Error led ON (rev A then rev B).
-		m2m_periph_gpio_set_val(M2M_PERIPH_GPIO18, 0);
-		m2m_periph_gpio_set_dir(M2M_PERIPH_GPIO6, 1);
+		if (ret != M2M_ERR_INVALID) {
+			// Error led ON (rev A then rev B).
+			m2m_periph_gpio_set_val(M2M_PERIPH_GPIO18, 0);
+			m2m_periph_gpio_set_dir(M2M_PERIPH_GPIO6, 1);
+		}
 #endif
 		return ret;
 	}

--- a/src/driver/source/m2m_hif.c
+++ b/src/driver/source/m2m_hif.c
@@ -600,7 +600,11 @@ static sint8 hif_isr(void)
 		{
 #ifndef WIN32
 			M2M_ERR("(hif) False interrupt %lx",reg);
+#ifdef ARDUINO
+			// ignore false interrupts, since they cause infinite loops in hif_handle_isr
+#else
 			ret = M2M_ERR_FAIL;
+#endif
 			goto ERR1;
 #else
 #endif


### PR DESCRIPTION
This fixes #209.

@facchinm the Due seems to be getting "false" interrupts for some reason now. I made https://github.com/arduino-libraries/WiFi101/commit/48caad4021c2d405b143afb0221b96ee69d43016 to ignore these in this PR, however there might be a better way. The "false interrupt" condition basically results in an infinite loops anyways, so I think we can safely ignore it.

I also noticed not having the shield pulled in would result in `WiFi.status()` hanging because it tries to set the error LED on the shield. https://github.com/arduino-libraries/WiFi101/commit/ba2b2a9fa6a98006b0a29054a5723b7592e0e8f3 removes this attempt.