### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/MDNS_WiFiWebServer/MDNS_WiFiWebServer.ino
+++ b/examples/MDNS_WiFiWebServer/MDNS_WiFiWebServer.ino
@@ -103,7 +103,7 @@ void loop() {
   if (client) {
     Serial.println("new client");
     // an http request ends with a blank line
-    boolean currentLineIsBlank = true;
+    bool currentLineIsBlank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();

--- a/examples/Provisioning_WiFiWebServer/Provisioning_WiFiWebServer.ino
+++ b/examples/Provisioning_WiFiWebServer/Provisioning_WiFiWebServer.ino
@@ -99,7 +99,7 @@ void loop() {
   if (client) {
     Serial.println("new client");
     // an http request ends with a blank line
-    boolean currentLineIsBlank = true;
+    bool currentLineIsBlank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();

--- a/examples/WiFiChatServer/WiFiChatServer.ino
+++ b/examples/WiFiChatServer/WiFiChatServer.ino
@@ -33,7 +33,7 @@ int status = WL_IDLE_STATUS;
 
 WiFiServer server(23);
 
-boolean alreadyConnected = false; // whether or not the client was connected previously
+bool alreadyConnected = false; // whether or not the client was connected previously
 
 void setup() {
   //Initialize serial and wait for port to open:

--- a/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/examples/WiFiWebServer/WiFiWebServer.ino
@@ -68,7 +68,7 @@ void loop() {
   if (client) {
     Serial.println("new client");
     // an http request ends with a blank line
-    boolean currentLineIsBlank = true;
+    bool currentLineIsBlank = true;
     while (client.connected()) {
       if (client.available()) {
         char c = client.read();


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633