### PR TITLE
Fix socket initialization condition

### DIFF
--- a/src/utility/WiFiSocket.cpp
+++ b/src/utility/WiFiSocket.cpp
@@ -66,7 +66,7 @@ SOCKET WiFiSocketClass::create(uint16 u16Domain, uint8 u8Type, uint8 u8Flags)
 {
 	SOCKET sock = socket(u16Domain, u8Type, u8Flags);
 
-	if (sock > 0) {
+	if (sock >= 0) {
 		_info[sock].state = SOCKET_STATE_IDLE;
 		_info[sock].parent = -1;
 	}


### PR DESCRIPTION
The socket() method returns a socket handle (0+) on success or -1 on failure. The original condition therefore only initializes the socket state and parent value after the first TCP socket is created.