### PR TITLE
Fix endPacket() return value if socket is unbound

### DIFF
--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -137,7 +137,7 @@ int WiFiUDP::endPacket()
 
 	int result = WiFiSocket.sendto(_socket, (void *)_sndBuffer, _sndSize, 0, (struct sockaddr *)&addr, sizeof(addr));
 
-	return (result < 0) ? 0 : 1;
+	return (result <= 0) ? 0 : 1;
 }
 
 size_t WiFiUDP::write(uint8_t byte)


### PR DESCRIPTION
The `endPacket()` method returns 0 (failure) only in the case where `WiFiSocket.sendto()` returns < 0. However, the `sendto()` method returns exactly 0 in the case where the socket is not in a BOUND state. This allows `endPacket()` to indicate success after `sendto()` indicates failure. The simple fix is to change the condition to be `<= 0` instead of `< 0`.