### PR TITLE
 Fix WiFiUDP::endPacket() return code, rev2

### DIFF
--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -132,7 +132,7 @@ int WiFiUDP::endPacket()
 
 	int result = WiFiSocket.sendto(_socket, (void *)_sndBuffer, _sndSize, 0, (struct sockaddr *)&addr, sizeof(addr));
 
-	return (result <= 0) ? 0 : 1;
+	return (result < 0) ? 0 : 1;
 }
 
 size_t WiFiUDP::write(uint8_t byte)

--- a/src/utility/WiFiSocket.cpp
+++ b/src/utility/WiFiSocket.cpp
@@ -319,7 +319,7 @@ sint16 WiFiSocketClass::sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLe
 	m2m_wifi_handle_events(NULL);
 
 	if (_info[sock].state != SOCKET_STATE_BOUND) {
-		return 0;
+		return -1;
 	}
 
 	return ::sendto(sock, pvSendBuffer, u16SendLength, flags, pstrDestAddr, u8AddrLen);


### PR DESCRIPTION
In utility/WiFiSocket.cpp the not bound state returns 0 (and is an error), but the call after to sendtoSocket will return SOCK_ERR_NO_ERROR, which is defined as 0 in socket/include/socket.h. So, it appears a return from WiFiSocketClass::sendto of 0 can mean both error and not error. The not bound check:
```
   if (_info[sock].state != SOCKET_STATE_BOUND) {
      return 0;
   }
```
in should be updated to return -1, and the return logic for WiFiUDP::endPacket() should check for "<" (and not "<=").