### PR TITLE
Changed arduino.cc in example.org

### DIFF
--- a/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
+++ b/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino
@@ -32,7 +32,7 @@ int status = WL_IDLE_STATUS;
 WiFiClient client;
 
 // server address:
-char server[] = "arduino.cc";
+char server[] = "example.org";
 //IPAddress server(64,131,82,241);
 
 unsigned long lastConnectionTime = 0;            // last time you connected to the server, in milliseconds
@@ -93,8 +93,8 @@ void httpRequest() {
   if (client.connect(server, 80)) {
     Serial.println("connecting...");
     // send the HTTP PUT request:
-    client.println("GET /asciilogo.txt HTTP/1.1");
-    client.println("Host: arduino.cc");
+    client.println("GET / HTTP/1.1");
+    client.println("Host: example.org");
     client.println("User-Agent: ArduinoWiFi/1.1");
     client.println("Connection: close");
     client.println();


### PR DESCRIPTION
Changed the server url in WiFiWebClientRepeating.ino example, due to the dismission of http://arduino.cc
cc/ @sandeepmistry 

resolve https://github.com/arduino-libraries/WiFi101/issues/248