### PR TITLE
Use send API to send UDP packets if the IP address and port of the last sendto was the same

### DIFF
--- a/src/utility/WiFiSocket.cpp
+++ b/src/utility/WiFiSocket.cpp
@@ -55,6 +55,7 @@ WiFiSocketClass::WiFiSocketClass()
 		_info[i].buffer.data = NULL;
 		_info[i].buffer.head = NULL;
 		_info[i].buffer.length = 0;
+		memset(&_info[i]._lastSendtoAddr, 0x00, sizeof(_info[i]._lastSendtoAddr));
 	}
 }
 
@@ -322,7 +323,13 @@ sint16 WiFiSocketClass::sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLe
 		return -1;
 	}
 
-	return ::sendto(sock, pvSendBuffer, u16SendLength, flags, pstrDestAddr, u8AddrLen);
+	if (memcmp(&_info[sock]._lastSendtoAddr, pstrDestAddr, sizeof(_info[sock]._lastSendtoAddr)) != 0) {
+		memcpy(&_info[sock]._lastSendtoAddr, pstrDestAddr, sizeof(_info[sock]._lastSendtoAddr));
+
+		return ::sendto(sock, pvSendBuffer, u16SendLength, flags, pstrDestAddr, u8AddrLen);
+	} else {
+		return ::send(sock, pvSendBuffer, u16SendLength, 0);
+	}	
 }
 
 sint8 WiFiSocketClass::close(SOCKET sock)
@@ -348,6 +355,7 @@ sint8 WiFiSocketClass::close(SOCKET sock)
 	_info[sock].buffer.head = NULL;
 	_info[sock].buffer.length = 0;
 	_info[sock].recvMsg.s16BufferSize = 0;
+	memset(&_info[sock]._lastSendtoAddr, 0x00, sizeof(_info[sock]._lastSendtoAddr));
 
 	return ::close(sock);
 }

--- a/src/utility/WiFiSocket.h
+++ b/src/utility/WiFiSocket.h
@@ -68,6 +68,7 @@ private:
       uint8_t* head;
       int length;
     } buffer;
+    struct sockaddr _lastSendtoAddr;
   } _info[MAX_SOCKET];
 };
 


### PR DESCRIPTION
This is a workaround suggested to Microchip to solve #229.

The downside of this change is it takes 16 * 7 bytes of additional RAM.