### PR TITLE
socket: Rename close() to sock_close()

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -89,7 +89,7 @@ void WiFiClass::handleEvent(uint8_t u8MsgType, void *pvMsg)
 					// Close sockets to clean state
 					// Clients will need to reconnect once the physical link will be re-established
 					for (int i = 0; i < MAX_SOCKET; i++) {
-						WiFiSocket.close(i);
+						WiFiSocket.sock_close(i);
 					}
 				} else if (_mode == WL_AP_MODE) {
 					_status = WL_AP_LISTENING;
@@ -686,7 +686,7 @@ void WiFiClass::disconnect()
 {
 	// Close sockets to clean state
 	for (int i = 0; i < MAX_SOCKET; i++) {
-		WiFiSocket.close(i);
+		WiFiSocket.sock_close(i);
 	}
 
 	m2m_wifi_disconnect();
@@ -702,7 +702,7 @@ void WiFiClass::end()
 {
 	// Close sockets to clean state
 	for (int i = 0; i < MAX_SOCKET; i++) {
-		WiFiSocket.close(i);
+		WiFiSocket.sock_close(i);
 	}
 
 	if (_mode == WL_AP_MODE) {

--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -86,7 +86,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, uint8_t opt, const uint8_t 
 
 	// Connect to remote host:
 	if (!WiFiSocket.connect(_socket, (struct sockaddr *)&addr, sizeof(struct sockaddr_in))) {
-		WiFiSocket.close(_socket);
+		WiFiSocket.sock_close(_socket);
 		_socket = -1;
 		return 0;
 	}
@@ -174,7 +174,7 @@ void WiFiClient::stop()
 		return;
 	}
 
-	WiFiSocket.close(_socket);
+	WiFiSocket.sock_close(_socket);
 
 	_socket = -1;
 }

--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -48,7 +48,7 @@ uint8_t WiFiServer::begin(uint8_t opt)
 	addr.sin_addr.s_addr = 0;
 
 	if (_socket != -1 && WiFiSocket.listening(_socket)) {
-		WiFiSocket.close(_socket);
+		WiFiSocket.sock_close(_socket);
 		_socket = -1;
 	}
 
@@ -59,14 +59,14 @@ uint8_t WiFiServer::begin(uint8_t opt)
 
 	// Bind socket:
 	if (!WiFiSocket.bind(_socket, (struct sockaddr *)&addr, sizeof(struct sockaddr_in))) {
-		WiFiSocket.close(_socket);
+		WiFiSocket.sock_close(_socket);
 		_socket = -1;
 		return 0;
 	}
 
 	// Listen socket:
 	if (!WiFiSocket.listen(_socket, 0)) {
-		WiFiSocket.close(_socket);
+		WiFiSocket.sock_close(_socket);
 		_socket = -1;
 		return 0;
 	}

--- a/src/WiFiUdp.cpp
+++ b/src/WiFiUdp.cpp
@@ -47,7 +47,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
 	addr.sin_addr.s_addr = 0;
 
 	if (_socket != -1 && WiFiSocket.bound(_socket)) {
-		WiFiSocket.close(_socket);
+		WiFiSocket.sock_close(_socket);
 		_socket = -1;
 	}
 
@@ -60,7 +60,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
 
 	// Bind socket:
 	if (!WiFiSocket.bind(_socket, (struct sockaddr *)&addr, sizeof(struct sockaddr_in))) {
-		WiFiSocket.close(_socket);
+		WiFiSocket.sock_close(_socket);
 		_socket = -1;
 		return 0;
 	}
@@ -103,7 +103,7 @@ void WiFiUDP::stop()
 		return;
 	}
 
-	WiFiSocket.close(_socket);
+	WiFiSocket.sock_close(_socket);
 	_socket = -1;
 }
 

--- a/src/socket/include/socket.h
+++ b/src/socket/include/socket.h
@@ -1194,7 +1194,7 @@ NMI_API SOCKET socket(uint16 u16Domain, uint8 u8Type, uint8 u8Flags);
 			if(ret != 0)
 			{
 				printf("Bind Failed. Error code = %d\n",ret);
-				close(udpServerSocket);
+				sock_close(udpServerSocket);
 			}
 		}
 		else
@@ -1279,7 +1279,7 @@ This example demonstrates the call of the listen socket operation after a succes
 					else
 					{
 						M2M_ERR("bind Failure!\n");
-						close(sock);
+						sock_close(sock);
 					}
 				}
 			}
@@ -1298,7 +1298,7 @@ This example demonstrates the call of the listen socket operation after a succes
 					else
 					{
 						M2M_ERR("listen Failure!\n");
-						close(sock);
+						sock_close(sock);
 					}
 				}
 			}
@@ -1456,7 +1456,7 @@ NMI_API sint8 accept(SOCKET sock, struct sockaddr *addr, uint8 *addrlen);
 		else
 		{
 			M2M_DBG("Connection Failed, Error: %d\n",pstrConnect->s8Error");
-			close(pstrNotification->Socket);
+			sock_close(pstrNotification->Socket);
 		}
 	}
 @endcode
@@ -1560,7 +1560,7 @@ NMI_API sint8 connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen);
 			else
 			{
 				printf("Socet recv Error: %d\n",pstrRx->s16BufferSize);
-				close(sock);
+				sock_close(sock);
 			}
 		}
 		break;
@@ -1674,7 +1674,7 @@ NMI_API sint16 recv(SOCKET sock, void *pvRecvBuf, uint16 u16BufLen, uint32 u32Ti
 			else
 			{
 				printf("Socet recv Error: %d\n",pstrRx->s16BufferSize);
-				ret = close(sock);
+				ret = sock_close(sock);
 			}
 		}
 		break;
@@ -1816,7 +1816,7 @@ NMI_API sint16 sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uin
  /**@{*/
 /*!
 @fn	\
-	NMI_API sint8 close(SOCKET sock);
+	NMI_API sint8 sock_close(SOCKET sock);
 
 @param [in]	sock
 				Socket ID, must hold a non negative value.
@@ -1836,7 +1836,7 @@ NMI_API sint16 sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uin
 @return		
 	The function returned @ref SOCK_ERR_NO_ERROR for successful operation and a negative value (indicating the error) otherwise. 
 */
-NMI_API sint8 close(SOCKET sock);
+NMI_API sint8 sock_close(SOCKET sock);
 /** @} */
 /** @defgroup InetAddressFn nmi_inet_addr
 *  @ingroup SocketAPI

--- a/src/socket/source/socket.c
+++ b/src/socket/source/socket.c
@@ -963,7 +963,7 @@ Version
 Date
 		4 June 2012
 *********************************************************************/
-sint8 close(SOCKET sock)
+sint8 sock_close(SOCKET sock)
 {
 	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
     M2M_INFO("Sock to delete <%d>\n", sock);

--- a/src/utility/WiFiSocket.cpp
+++ b/src/utility/WiFiSocket.cpp
@@ -332,7 +332,7 @@ sint16 WiFiSocketClass::sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLe
 	}	
 }
 
-sint8 WiFiSocketClass::close(SOCKET sock)
+sint8 WiFiSocketClass::sock_close(SOCKET sock)
 {
 	m2m_wifi_handle_events(NULL);
 
@@ -357,7 +357,7 @@ sint8 WiFiSocketClass::close(SOCKET sock)
 	_info[sock].recvMsg.s16BufferSize = 0;
 	memset(&_info[sock]._lastSendtoAddr, 0x00, sizeof(_info[sock]._lastSendtoAddr));
 
-	return ::close(sock);
+	return ::sock_close(sock);
 }
 
 int WiFiSocketClass::hasParent(SOCKET sock, SOCKET child)
@@ -455,7 +455,7 @@ void WiFiSocketClass::handleEvent(SOCKET sock, uint8 u8Msg, void *pvMsg)
 #endif
 
 			if (pstrRecvMsg->s16BufferSize <= 0) {
-				close(sock);
+				sock_close(sock);
 			} else if (_info[sock].state == SOCKET_STATE_CONNECTED || _info[sock].state == SOCKET_STATE_BOUND) {
 				_info[sock].recvMsg.pu8Buffer = pstrRecvMsg->pu8Buffer;
 				_info[sock].recvMsg.s16BufferSize = pstrRecvMsg->s16BufferSize;

--- a/src/utility/WiFiSocket.h
+++ b/src/utility/WiFiSocket.h
@@ -48,7 +48,7 @@ public:
   sint16 sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uint16 flags, struct sockaddr *pstrDestAddr, uint8 u8AddrLen);
   IPAddress remoteIP(SOCKET sock);
   uint16_t remotePort(SOCKET sock);
-  sint8 close(SOCKET sock);
+  sint8 sock_close(SOCKET sock);
   SOCKET accepted(SOCKET sock);
   int hasParent(SOCKET sock, SOCKET child);
 


### PR DESCRIPTION
The close() function can conflict with the POSIX close() [1] function
name. This results in the WiFi101 library failing to build when
targeting the RISC-V based HiFive 1 board with a redefinition of
function error.

As the name is already commonly used to refer to closing file
descriptors (not sockets) and the function is internal to the library it
makes sense to rename the function to something more socket
orientated.

1: https://linux.die.net/man/2/close

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>