### PR TITLE
Force enable and reset to be low when deiniting chip

### DIFF
--- a/src/bsp/source/nm_bsp_arduino.c
+++ b/src/bsp/source/nm_bsp_arduino.c
@@ -92,7 +92,8 @@ static void init_chip_pins(void)
 	if (gi8Winc1501ChipEnPin > -1)
 	{
 		/* Configure CHIP_EN as pull-up */
-		pinMode(gi8Winc1501ChipEnPin, INPUT_PULLUP);
+		pinMode(gi8Winc1501ChipEnPin, OUTPUT);
+		digitalWrite(gi8Winc1501ChipEnPin, HIGH);
 	}
 }
 
@@ -101,12 +102,11 @@ static void deinit_chip_pins(void)
 	if (gi8Winc1501ResetPin > -1)
 	{
 		digitalWrite(gi8Winc1501ResetPin, LOW);
-		pinMode(gi8Winc1501ResetPin, INPUT);
 	}
 
 	if (gi8Winc1501ChipEnPin > -1)
 	{
-		pinMode(gi8Winc1501ChipEnPin, INPUT);
+		digitalWrite(gi8Winc1501ChipEnPin, LOW);
 	}
 }
 


### PR DESCRIPTION
Currently, when deiniting the WiFi chip via `WiFi.end()`, the enable pin is left floating.

As per the [data sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/ATWINC15x0-MR210xB-IEEE-802.11-b-g-n-SmartConnect-IoT-Module-Data-Sheet-DS70005304C.pdf) section 8.4 (Power up/down sequence), both the `enable` and `reset` pins must be asserted high or low, and never left floating:

> CHIP_EN must not rise before VDDIO. CHIP_EN must be driven high or low, not left floating

> RESETN must be driven high or low, not left floating.

This PR addresses this by ensuring both pins are output (enable was INPUT_PULLUP), and force asserting both pins low on deinit. This appears safe, as the enable and reset pins do not appear to be used by any other piece of code in the WiFi101 library.