### PR TITLE
WiFi.h for including in super libraries

### DIFF
--- a/src/WiFi.h
+++ b/src/WiFi.h
@@ -1,0 +1,1 @@
+#include <WiFi101.h>


### PR DESCRIPTION
if the sketch includes WiFi101.h a library will include the right WiFi.h.

This helps to create generic super libraries over all WiFi libraries which have WiFi.h like WiFi, WiFiNINA or my WiFiEspAT library. examples of super libraries are WiFi101OTA or the new WiFiWebServer library