### PR TITLE
WiFi object - IPAddress as return type for IP getters

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -748,17 +748,17 @@ uint8_t *WiFiClass::macAddress(uint8_t *mac)
 	return mac;
 }
 
-uint32_t WiFiClass::localIP()
+IPAddress WiFiClass::localIP()
 {
 	return _localip;
 }
 
-uint32_t WiFiClass::subnetMask()
+IPAddress WiFiClass::subnetMask()
 {
 	return _submask;
 }
 
-uint32_t WiFiClass::gatewayIP()
+IPAddress WiFiClass::gatewayIP()
 {
 	return _gateway;
 }

--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -130,9 +130,9 @@ public:
 
 	uint8_t *macAddress(uint8_t *mac);
 
-	uint32_t localIP();
-	uint32_t subnetMask();
-	uint32_t gatewayIP();
+	IPAddress localIP();
+	IPAddress subnetMask();
+	IPAddress gatewayIP();
 	char* SSID();
 	int32_t RSSI();
 	uint8_t encryptionType();


### PR DESCRIPTION
now the return type of WiFi.localIP(), gatewayIP() and subnetMask() is uint32_t.
```
IPAddress ip = WiFi.localIP();
Serial.println(ip);
```
works, but `Serial.println(WiFi.localIP());` prints a large number.

The return type should be IPAddress and `uint32_t raw = WiFi.localIP();` will still work, because IPAddress has the necessary operator.