### PR TITLE
server.available() according to reference. with example

### DIFF
--- a/examples/WiFiPagerServer/WiFiPagerServer.ino
+++ b/examples/WiFiPagerServer/WiFiPagerServer.ino
@@ -1,0 +1,72 @@
+/*
+  Pager Server
+
+  The example is a simple server that echoes any incoming
+  messages to all connected clients. Connect two or more
+  telnet sessions to see how server.available() and
+  server.print() work.
+
+ Circuit:
+ * WiFi 101 Shield attached
+
+*/
+
+#include <WiFi101.h>
+
+#include "arduino_secrets.h"
+///////please enter your sensitive data in the Secret tab/arduino_secrets.h
+char ssid[] = SECRET_SSID;        // your network SSID (name)
+char pass[] = SECRET_PASS;    // your network password (use for WPA, or use as key for WEP)
+
+int status = WL_IDLE_STATUS;
+
+WiFiServer server(23);
+
+void setup() {
+
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the WiFi module:
+  if (WiFi.status() == WL_NO_SHIELD) {
+    Serial.println("WiFi 101 Shield not present");
+    // don't continue
+    while (true);
+  }
+
+  // attempt to connect to WiFi network:
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(ssid);
+    // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
+    status = WiFi.begin(ssid, pass);
+
+    // wait 10 seconds for connection:
+    delay(10000);
+  }
+
+  server.begin();
+
+  IPAddress ip = WiFi.localIP();
+  Serial.println();
+  Serial.println("Connected to WiFi network.");
+  Serial.print("To access the server, connect with Telnet client to ");
+  Serial.print(ip);
+  Serial.println(" 23");
+}
+
+void loop() {
+
+  WiFiClient client = server.available(); // returns first client which has data to read or a 'false' client
+  if (client) { // client is true only if it is connected and has data to read
+    String s = client.readStringUntil('\n'); // read the message incoming from one of the clients
+    s.trim(); // trim eventual \r
+    Serial.println(s); // print the message to Serial Monitor
+    client.print("echo: "); // this is only for the sending client
+    server.println(s); // send the message to all connected clients
+    server.flush(); // flush the buffers
+  }
+}

--- a/examples/WiFiPagerServer/arduino_secrets.h
+++ b/examples/WiFiPagerServer/arduino_secrets.h
@@ -1,0 +1,2 @@
+#define SECRET_SSID ""
+#define SECRET_PASS ""

--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -85,11 +85,7 @@ WiFiClient WiFiServer::available(uint8_t* status)
 	}
 
 	if (_socket != -1) {
-		SOCKET child = WiFiSocket.accepted(_socket);
-
-		if (child > -1) {
-			return WiFiClient(child);
-		}
+		WiFiSocket.accepted(_socket);
 
 		for (SOCKET s = 0; s < TCP_SOCK_MAX; s++) {
 			if (WiFiSocket.hasParent(_socket, s) && WiFiSocket.available(s)) {


### PR DESCRIPTION
The reference for WiFi101 server.available() has
> Gets a client that is connected to the server and has data available for reading. 

which is same as for the Ethernet library and WiFiNINA library, and many other libraries implementing the Arduino networking API introduced by the Ethernet library.

But server.available() in WiFi101 library now returns a just connected client even if it doesn't have data available yet. (This is an interesting workaround for missing accept() function, but it is [causing problems](https://github.com/arduino-libraries/WiFi101/issues/318) sometimes even with the examples of the WiFi101 library.)

This PR fixes available() and [my other PR](https://github.com/arduino-libraries/WiFi101/pull/320) adds [accept()](https://www.arduino.cc/en/Reference/EthernetServerAccept), but the change of available() should be considered as **breaking change**, because sketch which expected server.available() to return new connected clients even without data, will break.

and the PR contains my example PagerServer (already accepted in Ethernet library) which concentrates on how server.available() and print-to-all-clients works.
