### PR TITLE
WiFiClient.setConnectionTimeout added

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -22,15 +22,21 @@
 #include "WiFi101.h"
 #include "WiFiClient.h"
 
+#ifndef WIFI101_CLIENT_CONNECTION_TIMEOUT
+#define WIFI101_CLIENT_CONNECTION_TIMEOUT 20000
+#endif
+
 WiFiClient::WiFiClient()
 {
 	_socket = -1;
+	_timeout = WIFI101_CLIENT_CONNECTION_TIMEOUT;
 }
 
 WiFiClient::WiFiClient(uint8_t sock)
 {
 	// Spawn connected TCP client from TCP server socket:
 	_socket = sock;
+	_timeout = WIFI101_CLIENT_CONNECTION_TIMEOUT;
 }
 
 int WiFiClient::connectSSL(const char* host, uint16_t port)
@@ -85,7 +91,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port, uint8_t opt, const uint8_t 
 	}
 
 	// Connect to remote host:
-	if (!WiFiSocket.connect(_socket, (struct sockaddr *)&addr, sizeof(struct sockaddr_in))) {
+	if (!WiFiSocket.connect(_socket, (struct sockaddr *)&addr, sizeof(struct sockaddr_in), _timeout)) {
 		WiFiSocket.close(_socket);
 		_socket = -1;
 		return 0;

--- a/src/WiFiClient.h
+++ b/src/WiFiClient.h
@@ -58,8 +58,11 @@ public:
 	virtual IPAddress remoteIP();
 	virtual uint16_t remotePort();
 
+	void setConnectionTimeout(uint16_t timeout) { _timeout = timeout; }
+
 private:
 	SOCKET _socket;
+	uint16_t _timeout;
 
 	int connect(const char* host, uint16_t port, uint8_t opt);
 	int connect(IPAddress ip, uint16_t port, uint8_t opt, const uint8_t *hostname);

--- a/src/utility/WiFiSocket.cpp
+++ b/src/utility/WiFiSocket.cpp
@@ -132,7 +132,7 @@ sint8 WiFiSocketClass::setopt(SOCKET socket, uint8 u8Level, uint8 option_name, c
 	return setsockopt(socket, u8Level, option_name, option_value, u16OptionLen);
 }
 
-sint8 WiFiSocketClass::connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen)
+sint8 WiFiSocketClass::connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen, uint16 timeout)
 {
 	if (::connect(sock, pstrAddr, u8AddrLen) < 0) {
 		return 0;
@@ -142,7 +142,7 @@ sint8 WiFiSocketClass::connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8A
 
 	unsigned long start = millis();
 
-	while (_info[sock].state == SOCKET_STATE_CONNECTING && millis() - start < 20000) {
+	while (_info[sock].state == SOCKET_STATE_CONNECTING && millis() - start < timeout) {
 		m2m_wifi_handle_events(NULL);
 	}
 

--- a/src/utility/WiFiSocket.h
+++ b/src/utility/WiFiSocket.h
@@ -37,7 +37,7 @@ public:
   sint8 bind(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen);
   sint8 listen(SOCKET sock, uint8 backlog);
   sint8 setopt(SOCKET socket, uint8 u8Level, uint8 option_name, const void *option_value, uint16 u16OptionLen);
-  sint8 connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen);
+  sint8 connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen, uint16 timeout);
   uint8 connected(SOCKET sock);
   uint8 listening(SOCKET sock);
   uint8 bound(SOCKET sock);


### PR DESCRIPTION
the connection timeout in WiFi101 library was hardcoded and is unreasonable long 20 seconds.
the Ethernet library has setConnectionTimeout. 
this PR adds setConnectionTimeout to WiFiClient. 
default timeout is still 20 seconds but can be set with -DWIFI101_CLIENT_CONNECTION_TIMEOUT

overview of Client API in Arduino networking libraries:
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#client-getters-and-setters