### PR TITLE
WiFiServer operator bool

### DIFF
--- a/src/WiFiServer.cpp
+++ b/src/WiFiServer.cpp
@@ -106,6 +106,11 @@ uint8_t WiFiServer::status() {
 	return 0;
 }
 
+WiFiServer::operator bool()
+{
+	return (_socket != -1 && WiFiSocket.listening(_socket));
+}
+
 size_t WiFiServer::write(uint8_t b)
 {
 	return write(&b, 1);

--- a/src/WiFiServer.h
+++ b/src/WiFiServer.h
@@ -40,6 +40,7 @@ public:
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t *buf, size_t size);
 	uint8_t status();
+	explicit operator bool();
 
 	using Print::write;
 


### PR DESCRIPTION
For other WiFi libraries it is a problem to implement proper server.status(), but easy to implement operator bool.
Even WiFi101 has status(), it always just returns 0.

overview of Server implementations in libraries https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#server-class