### PR TITLE
wl_defintions.h wl_enc_type update

### DIFF
--- a/src/WiFi101.h
+++ b/src/WiFi101.h
@@ -53,10 +53,14 @@ typedef enum {
 } wl_status_t;
 
 /* Encryption modes */
-enum wl_enc_type {  /* Values map to 802.11 encryption suites... */
+enum wl_enc_type {  /* Values map to 802.11 Cipher Algorithm Identifier */
 	ENC_TYPE_WEP  = M2M_WIFI_SEC_WEP,
 	ENC_TYPE_TKIP = M2M_WIFI_SEC_WPA_PSK,
+	ENC_TYPE_WPA = ENC_TYPE_TKIP,
 	ENC_TYPE_CCMP = M2M_WIFI_SEC_802_1X,
+	ENC_TYPE_WPA2 = ENC_TYPE_CCMP,
+	ENC_TYPE_GCMP = 6,
+	ENC_TYPE_WPA3 = ENC_TYPE_GCMP,
 	/* ... except these two, 7 and 8 are reserved in 802.11-2007 */
 	ENC_TYPE_NONE = M2M_WIFI_SEC_OPEN,
 	ENC_TYPE_AUTO = M2M_WIFI_SEC_INVALID


### PR DESCRIPTION
The WiFiS3 library added ENC_TYPE_WPA, ENC_TYPE_WPA2 and ENC_TYPE_WPA3
so this PR updates wl_enc_type in this library