### PR TITLE
Remove superfluous get_mac_address call

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -737,12 +737,11 @@ void WiFiClass::end()
 
 uint8_t *WiFiClass::macAddress(uint8_t *mac)
 {
-	m2m_wifi_get_mac_address(mac);
-	byte tmpMac[6], i;
+	byte tmpMac[6];
 	
 	m2m_wifi_get_mac_address(tmpMac);
-	
-	for(i = 0; i < 6; i++)
+
+	for(int i = 0; i < 6; i++)
 		mac[i] = tmpMac[5-i];
 		
 	return mac;


### PR DESCRIPTION
This is a little improvement to avoid one unnecessary call to the low-level library `m2m_wifi_get_mac_address()` call.
I successfully tested the change with my Arduino MKR1000 WiFi.
